### PR TITLE
LC-181: adding getByUID endpoint for civilservant

### DIFF
--- a/src/main/java/uk/gov/cshr/civilservant/controller/CivilServantController.java
+++ b/src/main/java/uk/gov/cshr/civilservant/controller/CivilServantController.java
@@ -114,6 +114,13 @@ public class CivilServantController implements ResourceProcessor<RepositoryLinks
         return ResponseEntity.noContent().build();
     }
 
+    @GetMapping("/resource/{uid}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Resource<CivilServantResource>> getByUID(@PathVariable("uid") String uid) {
+        return civilServantRepository.findByIdentity(uid).map(
+                civilServant -> ResponseEntity.ok(civilServantResourceFactory.create(civilServant)))
+                .orElse(ResponseEntity.notFound().build());
+    }
 
     @Override
     public RepositoryLinksResource process(RepositoryLinksResource resource) {

--- a/src/test/java/uk/gov/cshr/civilservant/controller/CivilServantControllerTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/controller/CivilServantControllerTest.java
@@ -159,6 +159,19 @@ public class CivilServantControllerTest {
                 .andExpect(jsonPath("$.lineManagerEmailAddress").value("manager@domain.com"));
     }
 
+    @Test
+    public void shouldReturnNotFoundWhenRequestCivilServantByUidDoesntExist() throws Exception {
+        String uid = "uid";
+        
+        when(civilServantRepository.findByIdentity(uid)).thenReturn(Optional.empty());
+
+        mockMvc.perform(
+                get("/civilServants/" + uid).with(csrf())
+                        .accept(APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
     private CivilServant createCivilServant(String uid) {
         Identity identity = new Identity(uid);
         return new CivilServant(identity);


### PR DESCRIPTION
_Duplicate of https://github.com/Civil-Service-Human-Resources/civil-servant-registry-service/pull/83 which was reverted as part of a rebase._

https://cshrdigitalandanalysis.atlassian.net/browse/LC-181
https://cshrdigitalandanalysis.atlassian.net/browse/LC-280

Application was previously using the findByIdentity endpoint in the civilservantrepository, but this was not returning line manager objects, just the uid.

Explicitly defined a new getByUid endpoint so that /civilservants/uid can easily be called by other apps to get civilservant objects.

Added respective tests.