### PR TITLE
[lc-14] - Fix for org hierarchy bug, hierarchy check would only trave…

### DIFF
--- a/src/main/java/uk/gov/cshr/civilservant/service/AgencyTokenService.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/AgencyTokenService.java
@@ -56,7 +56,9 @@ public class AgencyTokenService {
             return true;
         } else if (organisationalUnit.hasChildren()) {
             for (OrganisationalUnit childUnit : organisationalUnit.getChildren()) {
-                return organisationContainsCode(childUnit, code);
+                if  (organisationContainsCode(childUnit, code)) {
+                    return true;
+                }
             }
         } else {
             return false;


### PR DESCRIPTION
…se the first child tree and ignore child siblings due to returning on the check rather than only returning when the result is true