### PR TITLE
Create table and endpoint for allowlisted domains

### DIFF
--- a/src/main/java/uk/gov/cshr/civilservant/controller/AllowlistedDomainController.java
+++ b/src/main/java/uk/gov/cshr/civilservant/controller/AllowlistedDomainController.java
@@ -1,0 +1,39 @@
+package uk.gov.cshr.civilservant.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.cshr.civilservant.domain.AllowlistedDomain;
+import uk.gov.cshr.civilservant.dto.AllowlistedDomainDto;
+import uk.gov.cshr.civilservant.dto.factory.AllowlistedDomainDtoFactory;
+import uk.gov.cshr.civilservant.service.AllowlistedDomainService;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestController
+@RequestMapping("/domains")
+public class AllowlistedDomainController {
+    private AllowlistedDomainService service;
+    private AllowlistedDomainDtoFactory dtoFactory;
+
+    public AllowlistedDomainController(AllowlistedDomainService service, AllowlistedDomainDtoFactory dtoFactory) {
+        this.service = service;
+        this.dtoFactory = dtoFactory;
+    }
+
+    @GetMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<List<AllowlistedDomainDto>> getAllDomains(){
+        List<AllowlistedDomain> allowlistedDomains = service.getAllAllowlistedDomains();
+        List<AllowlistedDomainDto> dtos = allowlistedDomains.stream()
+                .map(domain -> dtoFactory.create(domain))
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok((dtos));
+    }
+}

--- a/src/main/java/uk/gov/cshr/civilservant/domain/AllAllowlistedDomainDetails.java
+++ b/src/main/java/uk/gov/cshr/civilservant/domain/AllAllowlistedDomainDetails.java
@@ -1,0 +1,11 @@
+package uk.gov.cshr.civilservant.domain;
+
+import org.springframework.data.rest.core.config.Projection;
+
+@Projection(
+        name = "allAllowlistedDomainDetails",
+        types = {AllowlistedDomain.class}
+)
+public interface AllAllowlistedDomainDetails {
+    String getDomain();
+}

--- a/src/main/java/uk/gov/cshr/civilservant/domain/AllowlistedDomain.java
+++ b/src/main/java/uk/gov/cshr/civilservant/domain/AllowlistedDomain.java
@@ -1,0 +1,16 @@
+package uk.gov.cshr.civilservant.domain;
+
+import lombok.Data;
+
+import javax.persistence.*;
+
+@Data
+@Entity
+public class AllowlistedDomain implements RegistryEntity{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String domain;
+}

--- a/src/main/java/uk/gov/cshr/civilservant/dto/AllowlistedDomainDto.java
+++ b/src/main/java/uk/gov/cshr/civilservant/dto/AllowlistedDomainDto.java
@@ -1,0 +1,15 @@
+package uk.gov.cshr.civilservant.dto;
+
+import lombok.Data;
+
+@Data
+public class AllowlistedDomainDto {
+    private String domain;
+
+    public AllowlistedDomainDto(String domain) {
+        this.domain = domain;
+    }
+
+    public AllowlistedDomainDto() {
+    }
+}

--- a/src/main/java/uk/gov/cshr/civilservant/dto/factory/AllowlistedDomainDtoFactory.java
+++ b/src/main/java/uk/gov/cshr/civilservant/dto/factory/AllowlistedDomainDtoFactory.java
@@ -1,0 +1,15 @@
+package uk.gov.cshr.civilservant.dto.factory;
+
+import org.springframework.stereotype.Component;
+import uk.gov.cshr.civilservant.domain.AllowlistedDomain;
+import uk.gov.cshr.civilservant.dto.AllowlistedDomainDto;
+
+@Component
+public class AllowlistedDomainDtoFactory extends DtoFactory<AllowlistedDomainDto, AllowlistedDomain>{
+    @Override
+    public AllowlistedDomainDto create(AllowlistedDomain allowlistedDomain) {
+        AllowlistedDomainDto allowlistedDomainDto = new AllowlistedDomainDto();
+        allowlistedDomainDto.setDomain(allowlistedDomain.getDomain());
+        return allowlistedDomainDto;
+    }
+}

--- a/src/main/java/uk/gov/cshr/civilservant/repository/AllowlistedDomainRepository.java
+++ b/src/main/java/uk/gov/cshr/civilservant/repository/AllowlistedDomainRepository.java
@@ -1,0 +1,13 @@
+package uk.gov.cshr.civilservant.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+import uk.gov.cshr.civilservant.domain.AllAllowlistedDomainDetails;
+import uk.gov.cshr.civilservant.domain.AllowlistedDomain;
+
+@Repository
+@RepositoryRestResource(excerptProjection = AllAllowlistedDomainDetails.class)
+public interface AllowlistedDomainRepository extends JpaRepository<AllowlistedDomain, Long> {
+
+}

--- a/src/main/java/uk/gov/cshr/civilservant/service/AllowlistedDomainService.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/AllowlistedDomainService.java
@@ -1,0 +1,20 @@
+package uk.gov.cshr.civilservant.service;
+
+import org.springframework.stereotype.Service;
+import uk.gov.cshr.civilservant.domain.AllowlistedDomain;
+import uk.gov.cshr.civilservant.repository.AllowlistedDomainRepository;
+
+import java.util.List;
+
+@Service
+public class AllowlistedDomainService {
+    private final AllowlistedDomainRepository allowlistedDomainRepository;
+
+    public AllowlistedDomainService(AllowlistedDomainRepository allowlistedDomainRepository) {
+        this.allowlistedDomainRepository = allowlistedDomainRepository;
+    }
+
+    public List<AllowlistedDomain> getAllAllowlistedDomains(){
+        return allowlistedDomainRepository.findAll();
+    }
+}

--- a/src/main/resources/db/migration/h2/V1.18__create-allowlisted-domain-table.sql
+++ b/src/main/resources/db/migration/h2/V1.18__create-allowlisted-domain-table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS allowlisted_domain(
+    `id`        SMALLINT(5)     UNSIGNED    NOT NULL AUTO_INCREMENT,
+    `domain`    VARCHAR(255)                NOT NULL,
+    PRIMARY KEY (`id`)
+    )
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8;

--- a/src/main/resources/db/migration/mysql/V1.18__create-allowlisted-domain-table.sql
+++ b/src/main/resources/db/migration/mysql/V1.18__create-allowlisted-domain-table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS allowlisted_domain(
+    `id`        SMALLINT(5)     UNSIGNED    NOT NULL AUTO_INCREMENT,
+    `domain`    VARCHAR(255)                NOT NULL,
+    PRIMARY KEY (`id`)
+    )
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8;


### PR DESCRIPTION
This change:

* Creates a new table in the CSRS database: `allowlisted_domain`
* Creates an endpoint `GET /domains` for getting the list of all domains