### PR TITLE
New endpoint for removing parent organisation

### DIFF
--- a/src/main/java/uk/gov/cshr/civilservant/controller/OrganisationalUnitController.java
+++ b/src/main/java/uk/gov/cshr/civilservant/controller/OrganisationalUnitController.java
@@ -173,6 +173,14 @@ public class OrganisationalUnitController {
         }
     }
 
+    @DeleteMapping("/{organisationalUnitId}/parent")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity removeParentOrganisation(@PathVariable Long organisationalUnitId){
+        Optional<OrganisationalUnit> organisationalUnit = organisationalUnitService.getOrganisationalUnit(organisationalUnitId);
+        organisationalUnitService.removeParentOrganisation(organisationalUnit.get());
+        return new ResponseEntity(HttpStatus.OK);
+    }
+
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public Map<String, String> handleValidationExceptions(

--- a/src/main/java/uk/gov/cshr/civilservant/service/OrganisationalUnitService.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/OrganisationalUnitService.java
@@ -145,6 +145,12 @@ public class OrganisationalUnitService extends SelfReferencingEntityService<Orga
         return updateOrgUnit;
     }
 
+    public OrganisationalUnit removeParentOrganisation(OrganisationalUnit organisationalUnit){
+        organisationalUnit.setParent(null);
+        repository.save(organisationalUnit);
+        return organisationalUnit;
+    }
+
     public List<String> getOrganisationalUnitCodes() {
         List<String> allCodes = repository.findAllCodes();
         Collections.sort(allCodes, String.CASE_INSENSITIVE_ORDER);


### PR DESCRIPTION
This change creates a new endpoint `DELETE /{organisationalUnitId}/parent` which deletes the parent organisation from the organisational unit with ID `organisationalUnitId` (sets `parent_id` to `NULL` in the database)