### PR TITLE
Update MySQL Connector

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ dependencies {
     compile group: 'org.hibernate', name: 'hibernate-entitymanager', version: '5.2.16.Final'
 
     // https://mvnrepository.com/artifact/mysql/mysql-connector-java
-    compile group: 'mysql', name: 'mysql-connector-java', version: '8.0.8-dmr'
+    compile group: 'mysql', name: 'mysql-connector-java', version: '8.0.13'
 
     // https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'


### PR DESCRIPTION
Part of the fixing the missing patches is to upgrade MySQL to version 8.0. To accommodate for this, the MySQL Connector needs to be updated to version 8.0.13