### PR TITLE
Update notification email to line manager

### DIFF
--- a/src/main/java/uk/gov/cshr/civilservant/service/LineManagerService.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/LineManagerService.java
@@ -12,6 +12,8 @@ import uk.gov.cshr.civilservant.service.identity.IdentityFromService;
 import uk.gov.cshr.civilservant.service.identity.IdentityService;
 import uk.gov.service.notify.NotificationClientException;
 
+import java.util.HashMap;
+
 @Service
 public class LineManagerService {
 
@@ -40,9 +42,19 @@ public class LineManagerService {
     String lineManagerName = defaultIfNull(lineManager.getFullName(), "");
 
     try {
-      notifyService.notify(email, govNotifyLineManagerTemplateId, lineManagerName, learnerName);
+      HashMap<String, String> personalisation = getLineManagerNotificationPersonalisation(lineManagerName, learnerName, identityService.getEmailAddress(civilServant));
+      notifyService.notify(email, govNotifyLineManagerTemplateId, personalisation);
     } catch (NotificationClientException nce) {
       LOGGER.error("Could not send Line Manager notification", nce);
     }
+  }
+
+  private HashMap<String, String> getLineManagerNotificationPersonalisation(String lineManagerName, String learnerName, String learnerEmail) {
+    HashMap<String, String> personalisation = new HashMap<>();
+    personalisation.put("lineManagerName", lineManagerName);
+    personalisation.put("learnerName", learnerName);
+    personalisation.put("learnerEmailAddress", learnerEmail);
+
+    return personalisation;
   }
 }

--- a/src/main/java/uk/gov/cshr/civilservant/service/NotifyService.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/NotifyService.java
@@ -14,30 +14,12 @@ import uk.gov.service.notify.SendEmailResponse;
 public class NotifyService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(NotifyService.class);
-  private static final String NAME_PERSONALISATION = "name";
-  private static final String LEARNER_PERSONALISATION = "learner";
 
   @Value("${govNotify.key}")
   private String govNotifyKey;
 
   @Value("${govNotify.enabled}")
   private Boolean enabled;
-
-  public void notify(String email, String templateId, String name, String learner)
-      throws NotificationClientException {
-    if (enabled) {
-      HashMap<String, String> personalisation = new HashMap<>();
-      personalisation.put(NAME_PERSONALISATION, name);
-      personalisation.put(LEARNER_PERSONALISATION, learner);
-
-      NotificationClient client = new NotificationClient(govNotifyKey);
-      SendEmailResponse response = client.sendEmail(templateId, email, personalisation, "");
-
-      LOGGER.debug("Line manager notification email: {}", response.getBody());
-    } else {
-      LOGGER.info("Gov Notify disabled - email {}, name {}, learner {}", email, name, learner);
-    }
-  }
 
   public void notify(String email, String templateId, HashMap<String, String> personalisation) throws NotificationClientException {
     if(enabled){

--- a/src/main/java/uk/gov/cshr/civilservant/service/NotifyService.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/NotifyService.java
@@ -38,4 +38,15 @@ public class NotifyService {
       LOGGER.info("Gov Notify disabled - email {}, name {}, learner {}", email, name, learner);
     }
   }
+
+  public void notify(String email, String templateId, HashMap<String, String> personalisation) throws NotificationClientException {
+    if(enabled){
+      NotificationClient client = new NotificationClient(govNotifyKey);
+      SendEmailResponse response = client.sendEmail(templateId, email, personalisation, "");
+      LOGGER.debug("Line manager notification email: {}", response.getBody());
+    }
+    else{
+      LOGGER.info("Gov Notify disabled - email {}, personalisation {}", email, personalisation.toString());
+    }
+  }
 }

--- a/src/test/java/uk/gov/cshr/civilservant/service/LineManagerServiceTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/service/LineManagerServiceTest.java
@@ -62,13 +62,13 @@ public class LineManagerServiceTest {
     lineManager.setUsername(lineManagerEmail);
 
     HashMap<String, String> expectedPersonalisation = new HashMap<>();
-    expectedPersonalisation.put("lineManagerName", lineManagerEmail);
+    expectedPersonalisation.put("lineManagerName", lineManagerName);
     expectedPersonalisation.put("learnerName", learnerName);
     expectedPersonalisation.put("learnerEmailAddress", learnerEmail);
 
-    lineManagerService.notifyLineManager(learner, manager, "manager@domain.com");
+    lineManagerService.notifyLineManager(learner, manager, lineManagerEmail);
 
-    verify(notifyService).notify("manager@domain.com", null, expectedPersonalisation);
+    verify(notifyService).notify(lineManagerEmail, null, expectedPersonalisation);
   }
 
 }

--- a/src/test/java/uk/gov/cshr/civilservant/service/LineManagerServiceTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/service/LineManagerServiceTest.java
@@ -16,6 +16,8 @@ import uk.gov.cshr.civilservant.repository.CivilServantRepository;
 import uk.gov.cshr.civilservant.service.identity.IdentityFromService;
 import uk.gov.cshr.civilservant.service.identity.IdentityService;
 
+import java.util.HashMap;
+
 @RunWith(MockitoJUnitRunner.class)
 public class LineManagerServiceTest {
 
@@ -39,22 +41,34 @@ public class LineManagerServiceTest {
   }
 
   @Test
-  public void shouldNotifyLineManager() throws Exception {
+  public void testLineManagerServiceShouldNotifyTheLineManagerWhenNotifyLineManagerIsCalled() throws Exception {
+    String learnerName = "Learner Name";
+    String learnerEmail = "learner.name@domain.com";
+    String lineManagerName = "Linemanager Name";
+    String lineManagerEmail = "linemanager.name@domain.com";
 
     final Identity learnerIdentity = new Identity("uid");
     final CivilServant learner = new CivilServant(learnerIdentity);
-    learner.setFullName("learner");
+    learner.setFullName(learnerName);
+
+    when(identityService.getEmailAddress(learner)).thenReturn(learnerEmail);
 
     final Identity managerIdentity = new Identity("mid");
     final CivilServant manager = new CivilServant(managerIdentity);
-    manager.setFullName("fullName");
+    manager.setFullName(lineManagerName);
 
     final IdentityFromService lineManager = new IdentityFromService();
     lineManager.setUid(managerIdentity.getUid());
-    lineManager.setUsername("manager@domain.com");
+    lineManager.setUsername(lineManagerEmail);
+
+    HashMap<String, String> expectedPersonalisation = new HashMap<>();
+    expectedPersonalisation.put("lineManagerName", lineManagerEmail);
+    expectedPersonalisation.put("learnerName", learnerName);
+    expectedPersonalisation.put("learnerEmailAddress", learnerEmail);
 
     lineManagerService.notifyLineManager(learner, manager, "manager@domain.com");
 
-    verify(notifyService).notify("manager@domain.com", null, "fullName", "learner");
+    verify(notifyService).notify("manager@domain.com", null, expectedPersonalisation);
   }
+
 }


### PR DESCRIPTION
This change updates the service so that it uses a new template for sending emails to line managers after a user updates their line manager email in the settings:

* Created a new `notify()` method in `NotifyService` which expects email personalisation as an argument.
* Updated `notifyLineManager` method in `LineManagerService` to call the new `notify()` method.
* Updated the `LineManagerServiceTest` class to test the new functionality