### PR TITLE
LC-2477 User changes organisation (+ free agent logic)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,6 +159,9 @@ dependencies {
     testCompile 'org.powermock:powermock-module-junit4:1.7.4'
 
     testCompile 'org.mockito:mockito-core:2.8.47'
+    testCompile 'com.github.tomakehurst:wiremock-standalone:2.7.1'
+    testCompile 'org.eclipse.jetty:jetty-util'
+    testCompile 'org.eclipse.jetty:jetty-io'
 
 }
 

--- a/src/main/java/uk/gov/cshr/civilservant/controller/ApiExceptionHandler.java
+++ b/src/main/java/uk/gov/cshr/civilservant/controller/ApiExceptionHandler.java
@@ -56,7 +56,7 @@ public class ApiExceptionHandler {
   protected ResponseEntity<ErrorDto> handleAlreadyExistsException(CodedHttpException e) {
     LOGGER.error("HTTP exception ", e);
     ErrorDto error =
-            errorDtoFactory.create(Collections.singletonList(e.getApiCode().getCode().getDescription()), e.getApiCode());
+            errorDtoFactory.create(Collections.singletonList(e.getMessage()), e.getApiCode());
     return ResponseEntity.status(error.getStatus()).body(error);
   }
 }

--- a/src/main/java/uk/gov/cshr/civilservant/controller/CivilServantController.java
+++ b/src/main/java/uk/gov/cshr/civilservant/controller/CivilServantController.java
@@ -22,7 +22,7 @@ import uk.gov.cshr.civilservant.resource.CivilServantResource;
 import uk.gov.cshr.civilservant.resource.factory.CivilServantResourceFactory;
 import uk.gov.cshr.civilservant.service.CivilServantService;
 import uk.gov.cshr.civilservant.service.LineManagerService;
-import uk.gov.cshr.civilservant.service.identity.IdentityFromService;
+import uk.gov.cshr.civilservant.service.identity.IdentityDTO;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -91,7 +91,7 @@ public class CivilServantController implements ResourceProcessor<RepositoryLinks
 
         if (optionalCivilServant.isPresent()) {
 
-            IdentityFromService lineManagerIdentity = lineManagerService.checkLineManager(email);
+            IdentityDTO lineManagerIdentity = lineManagerService.checkLineManager(email);
             if (lineManagerIdentity == null) {
                 log.debug("Line manager email address not found in identity-service.");
                 return ResponseEntity.notFound().build();

--- a/src/main/java/uk/gov/cshr/civilservant/controller/CivilServantController.java
+++ b/src/main/java/uk/gov/cshr/civilservant/controller/CivilServantController.java
@@ -24,7 +24,6 @@ import uk.gov.cshr.civilservant.service.CivilServantService;
 import uk.gov.cshr.civilservant.service.LineManagerService;
 import uk.gov.cshr.civilservant.service.identity.IdentityFromService;
 
-import java.security.Principal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -66,7 +65,7 @@ public class CivilServantController implements ResourceProcessor<RepositoryLinks
 
     @GetMapping("/me")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<Resource<CivilServantResource>> get(Principal p) {
+    public ResponseEntity<Resource<CivilServantResource>> get() {
         log.debug("Getting civil servant details for logged in user");
 
         return civilServantRepository.findByPrincipal().map(

--- a/src/main/java/uk/gov/cshr/civilservant/controller/OrganisationalUnitController.java
+++ b/src/main/java/uk/gov/cshr/civilservant/controller/OrganisationalUnitController.java
@@ -129,6 +129,14 @@ public class OrganisationalUnitController {
         return organisationalUnitService.addDomainToOrganisation(organisationalUnitId, domainDto.getDomain());
     }
 
+    @DeleteMapping("/{organisationalUnitId}")
+    @PreAuthorize("isAuthenticated()")
+    @ResponseBody
+    @ResponseStatus(HttpStatus.OK)
+    public void deleteOrganisation(@PathVariable Long organisationalUnitId) {
+        organisationalUnitService.deleteOrganisationalUnit(organisationalUnitId);
+    }
+
     @DeleteMapping("/{organisationalUnitId}/domains/{domainId}")
     @PreAuthorize("isAuthenticated()")
     @ResponseBody

--- a/src/main/java/uk/gov/cshr/civilservant/controller/OrganisationalUnitController.java
+++ b/src/main/java/uk/gov/cshr/civilservant/controller/OrganisationalUnitController.java
@@ -129,14 +129,6 @@ public class OrganisationalUnitController {
         return organisationalUnitService.addDomainToOrganisation(organisationalUnitId, domainDto.getDomain());
     }
 
-    @DeleteMapping("/{organisationalUnitId}")
-    @PreAuthorize("isAuthenticated()")
-    @ResponseBody
-    @ResponseStatus(HttpStatus.OK)
-    public void deleteOrganisation(@PathVariable Long organisationalUnitId) {
-        organisationalUnitService.deleteOrganisationalUnit(organisationalUnitId);
-    }
-
     @DeleteMapping("/{organisationalUnitId}/domains/{domainId}")
     @PreAuthorize("isAuthenticated()")
     @ResponseBody

--- a/src/main/java/uk/gov/cshr/civilservant/domain/OrganisationalUnit.java
+++ b/src/main/java/uk/gov/cshr/civilservant/domain/OrganisationalUnit.java
@@ -38,6 +38,9 @@ public class OrganisationalUnit extends SelfReferencingEntity<OrganisationalUnit
     @Column(nullable = false)
     private LocalDateTime updatedTimestamp;
 
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "organisationalUnit")
+    private List<CivilServant> civilServants;
+
     public OrganisationalUnit(OrganisationalUnit organisationalUnit) {
         this.id = organisationalUnit.getId();
         this.code = organisationalUnit.getCode();
@@ -48,6 +51,7 @@ public class OrganisationalUnit extends SelfReferencingEntity<OrganisationalUnit
         this.setPaymentMethods(organisationalUnit.getPaymentMethods());
         this.agencyToken = organisationalUnit.agencyToken;
         this.domains = organisationalUnit.getDomains();
+        this.civilServants = organisationalUnit.getCivilServants();
         this.createdTimestamp = organisationalUnit.getCreatedTimestamp();
         this.updatedTimestamp = organisationalUnit.getUpdatedTimestamp();
     }
@@ -179,5 +183,10 @@ public class OrganisationalUnit extends SelfReferencingEntity<OrganisationalUnit
     @JsonIgnore
     public boolean doesDomainExist(String domain) {
         return this.domains.stream().anyMatch(d -> d.getDomain().equals(domain));
+    }
+
+    @JsonIgnore
+    public List<CivilServant> getCivilServants() {
+        return this.civilServants;
     }
 }

--- a/src/main/java/uk/gov/cshr/civilservant/dto/BulkUpdate.java
+++ b/src/main/java/uk/gov/cshr/civilservant/dto/BulkUpdate.java
@@ -2,13 +2,26 @@ package uk.gov.cshr.civilservant.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.cshr.civilservant.domain.RegistryEntity;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Data
 @AllArgsConstructor
-public class BulkUpdate {
+@NoArgsConstructor
+public class BulkUpdate<T extends RegistryEntity> {
 
-    private List<Long> updatedIds;
-    private List<Long> skippedIds;
+    private List<T> updated = new ArrayList<>();
+    private List<T> skipped = new ArrayList<>();
+
+    public List<Long> getUpdatedIds() {
+        return this.getUpdated().stream().map(RegistryEntity::getId).collect(Collectors.toList());
+    }
+
+    public List<Long> getSkippedIds() {
+        return this.getSkipped().stream().map(RegistryEntity::getId).collect(Collectors.toList());
+    }
 }

--- a/src/main/java/uk/gov/cshr/civilservant/dto/RemoveDomainFromOrgResponse.java
+++ b/src/main/java/uk/gov/cshr/civilservant/dto/RemoveDomainFromOrgResponse.java
@@ -2,19 +2,24 @@ package uk.gov.cshr.civilservant.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import uk.gov.cshr.civilservant.domain.OrganisationalUnit;
 
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Data
 @AllArgsConstructor
 public class RemoveDomainFromOrgResponse {
     Long primaryOrganisationId;
     DomainDto domain;
-    List<Long> updatedChildOrganisationIds = Collections.emptyList();
+    List<Long> updatedChildOrganisationIds;
 
-    public RemoveDomainFromOrgResponse(Long primaryOrganisationId, DomainDto domain) {
-        this.primaryOrganisationId = primaryOrganisationId;
-        this.domain = domain;
+    public static RemoveDomainFromOrgResponse fromBulkUpdate(Long primaryOrganisationId, DomainDto domain,
+                                                             BulkUpdate<OrganisationalUnit> bulkUpdate) {
+        return new RemoveDomainFromOrgResponse(primaryOrganisationId, domain, bulkUpdate
+                .getUpdatedIds()
+                .stream().filter(id -> !Objects.equals(id, primaryOrganisationId))
+                .collect(Collectors.toList()));
     }
 }

--- a/src/main/java/uk/gov/cshr/civilservant/dto/UpdateOrganisationDTO.java
+++ b/src/main/java/uk/gov/cshr/civilservant/dto/UpdateOrganisationDTO.java
@@ -4,5 +4,5 @@ import lombok.Data;
 
 @Data
 public class UpdateOrganisationDTO {
-    private String organisation;
+    private Long organisationalUnitId;
 }

--- a/src/main/java/uk/gov/cshr/civilservant/exception/apiCodes/ApiCode.java
+++ b/src/main/java/uk/gov/cshr/civilservant/exception/apiCodes/ApiCode.java
@@ -2,7 +2,9 @@ package uk.gov.cshr.civilservant.exception.apiCodes;
 
 public enum ApiCode {
     OU001(new ApiErrorCode("OU001", "Domain already exists on the organisational unit", 400)),
-    OU002(new ApiErrorCode("OU002", "Invalid domain format. Correct format is: 'example.gov.uk'", 400));
+    OU002(new ApiErrorCode("OU002", "Invalid domain format. Correct format is: 'example.gov.uk'", 400)),
+
+    CS001(new ApiErrorCode("CS001", "Civil servant email domain does not match organisation", 400));
 
     private final ApiErrorCode code;
 

--- a/src/main/java/uk/gov/cshr/civilservant/exception/civilServant/InvalidUserOrganisationException.java
+++ b/src/main/java/uk/gov/cshr/civilservant/exception/civilServant/InvalidUserOrganisationException.java
@@ -1,0 +1,10 @@
+package uk.gov.cshr.civilservant.exception.civilServant;
+
+import uk.gov.cshr.civilservant.exception.CodedHttpException;
+import uk.gov.cshr.civilservant.exception.apiCodes.ApiCode;
+
+public class InvalidUserOrganisationException extends CodedHttpException {
+    public InvalidUserOrganisationException(String message) {
+        super(message, ApiCode.CS001);
+    }
+}

--- a/src/main/java/uk/gov/cshr/civilservant/exception/organisationalUnit/OrganisationalUnitNotFoundException.java
+++ b/src/main/java/uk/gov/cshr/civilservant/exception/organisationalUnit/OrganisationalUnitNotFoundException.java
@@ -1,0 +1,10 @@
+package uk.gov.cshr.civilservant.exception.organisationalUnit;
+
+import uk.gov.cshr.civilservant.exception.NotFoundException;
+
+public class OrganisationalUnitNotFoundException extends NotFoundException {
+
+    public OrganisationalUnitNotFoundException(Long organisationalUnitId) {
+        super(String.format("Organisational unit with id '%s' not found", organisationalUnitId));
+    }
+}

--- a/src/main/java/uk/gov/cshr/civilservant/service/CivilServantService.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/CivilServantService.java
@@ -3,26 +3,75 @@ package uk.gov.cshr.civilservant.service;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.cshr.civilservant.domain.CivilServant;
+import uk.gov.cshr.civilservant.domain.Domain;
+import uk.gov.cshr.civilservant.domain.OrganisationalUnit;
 import uk.gov.cshr.civilservant.exception.CivilServantNotFoundException;
+import uk.gov.cshr.civilservant.exception.UserNotFoundException;
+import uk.gov.cshr.civilservant.exception.civilServant.InvalidUserOrganisationException;
+import uk.gov.cshr.civilservant.exception.organisationalUnit.OrganisationalUnitNotFoundException;
 import uk.gov.cshr.civilservant.repository.CivilServantRepository;
+import uk.gov.cshr.civilservant.repository.OrganisationalUnitRepository;
+import uk.gov.cshr.civilservant.service.identity.IdentityFromService;
+import uk.gov.cshr.civilservant.service.identity.IdentityService;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
 public class CivilServantService {
 
-    private CivilServantRepository civilServantRepository;
+    private final CivilServantRepository civilServantRepository;
+    private final IdentityService identityService;
+    private final OrganisationalUnitRepository organisationalUnitRepository;
 
-    public CivilServantService(CivilServantRepository civilServantRepository) {
+    public CivilServantService(CivilServantRepository civilServantRepository, IdentityService identityService, OrganisationalUnitRepository organisationalUnitRepository) {
         this.civilServantRepository = civilServantRepository;
+        this.identityService = identityService;
+        this.organisationalUnitRepository = organisationalUnitRepository;
     }
 
     public String getCivilServantUid() {
         CivilServant cs = civilServantRepository.findByPrincipal()
-                .orElseThrow(() -> new CivilServantNotFoundException());
+                .orElseThrow(CivilServantNotFoundException::new);
         if (cs.getIdentity() != null && cs.getIdentity().getUid() != null) {
             return cs.getIdentity().getUid();
         }
         throw new CivilServantNotFoundException();
+    }
+
+    public CivilServant updateMyOrganisationalUnit(Long organisationalUnitId) {
+        CivilServant cs = civilServantRepository.findByPrincipal()
+                .orElseThrow(CivilServantNotFoundException::new);
+        if (cs.getOrganisationalUnit().isPresent() &&
+            Objects.equals(cs.getOrganisationalUnit().get().getId(), organisationalUnitId)) {
+                log.warn(String.format("Civil servant '%s' tried to update to their current organisational unit (%s). Aborting.", cs.getId(), organisationalUnitId));
+                return cs;
+        }
+        String uid = cs.getIdentity().getUid();
+        IdentityFromService identity = identityService.getIdentityFromService(uid);
+        if (identity != null) {
+            OrganisationalUnit organisationalUnit = organisationalUnitRepository.findById(organisationalUnitId)
+                    .orElseThrow(() -> new OrganisationalUnitNotFoundException(organisationalUnitId));
+            String userDomain = identity.getEmailDomain();
+            if (identity.getRoles().contains("UNRESTRICTED_ORGANISATION")) {
+                log.info("User is an unrestricted organisaton user");
+                cs.setOrganisationalUnit(organisationalUnit);
+            } else if (organisationalUnit.doesDomainExist(userDomain)) {
+                cs.setOrganisationalUnit(organisationalUnit);
+                log.info("User is not an unrestricted organisaton user; removing user's admin roles");
+                identityService.removeReportingAccess(Collections.singletonList(uid));
+            } else {
+                throw new InvalidUserOrganisationException(String.format("User domain '%s' does not exist on organisation '%s', valid domains are: %s",
+                        userDomain, organisationalUnitId, organisationalUnit.getDomains().stream().map(Domain::getDomain).collect(Collectors.toList())));
+            }
+            civilServantRepository.saveAndFlush(cs);
+        } else {
+            log.error(String.format("User '%s' was not found in identity service", uid));
+            throw new UserNotFoundException(uid);
+        }
+        return cs;
     }
 
 }

--- a/src/main/java/uk/gov/cshr/civilservant/service/CivilServantService.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/CivilServantService.java
@@ -50,7 +50,7 @@ public class CivilServantService {
                 return cs;
         }
         String uid = cs.getIdentity().getUid();
-        IdentityDTO identity = identityService.getIdentityFromService(uid);
+        IdentityDTO identity = identityService.getidentity(uid);
         if (identity != null) {
             OrganisationalUnit organisationalUnit = organisationalUnitRepository.findById(organisationalUnitId)
                     .orElseThrow(() -> new OrganisationalUnitNotFoundException(organisationalUnitId));

--- a/src/main/java/uk/gov/cshr/civilservant/service/CivilServantService.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/CivilServantService.java
@@ -11,7 +11,7 @@ import uk.gov.cshr.civilservant.exception.civilServant.InvalidUserOrganisationEx
 import uk.gov.cshr.civilservant.exception.organisationalUnit.OrganisationalUnitNotFoundException;
 import uk.gov.cshr.civilservant.repository.CivilServantRepository;
 import uk.gov.cshr.civilservant.repository.OrganisationalUnitRepository;
-import uk.gov.cshr.civilservant.service.identity.IdentityFromService;
+import uk.gov.cshr.civilservant.service.identity.IdentityDTO;
 import uk.gov.cshr.civilservant.service.identity.IdentityService;
 
 import java.util.Collections;
@@ -50,7 +50,7 @@ public class CivilServantService {
                 return cs;
         }
         String uid = cs.getIdentity().getUid();
-        IdentityFromService identity = identityService.getIdentityFromService(uid);
+        IdentityDTO identity = identityService.getIdentityFromService(uid);
         if (identity != null) {
             OrganisationalUnit organisationalUnit = organisationalUnitRepository.findById(organisationalUnitId)
                     .orElseThrow(() -> new OrganisationalUnitNotFoundException(organisationalUnitId));

--- a/src/main/java/uk/gov/cshr/civilservant/service/LineManagerService.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/LineManagerService.java
@@ -1,16 +1,16 @@
 package uk.gov.cshr.civilservant.service;
 
-import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.cshr.civilservant.domain.CivilServant;
-import uk.gov.cshr.civilservant.service.identity.IdentityFromService;
+import uk.gov.cshr.civilservant.service.identity.IdentityDTO;
 import uk.gov.cshr.civilservant.service.identity.IdentityService;
 import uk.gov.service.notify.NotificationClientException;
+
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 
 @Service
 public class LineManagerService {
@@ -30,7 +30,7 @@ public class LineManagerService {
     this.notifyService = notifyService;
   }
 
-  public IdentityFromService checkLineManager(String email) {
+  public IdentityDTO checkLineManager(String email) {
     return identityService.findByEmail(email);
   }
 

--- a/src/main/java/uk/gov/cshr/civilservant/service/OrganisationalUnitService.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/OrganisationalUnitService.java
@@ -204,7 +204,7 @@ public class OrganisationalUnitService extends SelfReferencingEntityService<Orga
         return repository.findById(id);
     }
 
-    public OrganisationalUnit getAndThrowIfNotFound(Long id) {
+    public OrganisationalUnit getOrThrowIfNotFound(Long id) {
         return repository.findById(id).orElseThrow(
                 () -> new OrganisationalUnitNotFoundException(id));
     }
@@ -295,7 +295,7 @@ public class OrganisationalUnitService extends SelfReferencingEntityService<Orga
 
     public RemoveDomainFromOrgResponse removeDomainFromOrganisation(Long organisationalUnitId, Long domainId,
                                                                     boolean includeSubOrgs) {
-        OrganisationalUnit organisationalUnit = getAndThrowIfNotFound(organisationalUnitId);
+        OrganisationalUnit organisationalUnit = getOrThrowIfNotFound(organisationalUnitId);
         Domain domain = domainRepository.findById(domainId).orElseThrow(
                 () -> new NotFoundException(String.format("Domain with ID '%s' not found", domainId)));
         List<OrganisationalUnit> orgsForUpdate = Lists.newArrayList(organisationalUnit);

--- a/src/main/java/uk/gov/cshr/civilservant/service/OrganisationalUnitService.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/OrganisationalUnitService.java
@@ -141,15 +141,6 @@ public class OrganisationalUnitService extends SelfReferencingEntityService<Orga
         return organisationalUnits;
     }
 
-    public void deleteOrganisationalUnit(Long organisatonalUnitId) {
-        OrganisationalUnit organisationalUnit = repository.findById(organisatonalUnitId).orElseThrow(() -> new OrganisationalUnitNotFoundException(organisatonalUnitId));
-        List<OrganisationalUnit> list = organisationalUnit.getHierarchyAsFlatList();
-        List<String> affectedUids = list.stream()
-                .map(OrganisationalUnit::getCivilServants).flatMap(List::stream)
-                .map(cs -> cs.getIdentity().getUid()).collect(Collectors.toList());
-        identityService.removeReportingAccess(affectedUids);
-    }
-
     public OrganisationalUnit setAgencyToken(OrganisationalUnit organisationalUnit, AgencyToken agencyToken) {
         if (organisationalUnit.getAgencyToken() != null) {
             throw new TokenAlreadyExistsException(organisationalUnit.getId().toString());

--- a/src/main/java/uk/gov/cshr/civilservant/service/OrganisationalUnitService.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/OrganisationalUnitService.java
@@ -22,7 +22,7 @@ import uk.gov.cshr.civilservant.exception.organisationalUnit.OrganisationalUnitN
 import uk.gov.cshr.civilservant.repository.CivilServantRepository;
 import uk.gov.cshr.civilservant.repository.DomainRepository;
 import uk.gov.cshr.civilservant.repository.OrganisationalUnitRepository;
-import uk.gov.cshr.civilservant.service.identity.IdentityFromService;
+import uk.gov.cshr.civilservant.service.identity.IdentityDTO;
 import uk.gov.cshr.civilservant.service.identity.IdentityService;
 
 import java.util.*;
@@ -305,10 +305,10 @@ public class OrganisationalUnitService extends SelfReferencingEntityService<Orga
         BulkUpdate<OrganisationalUnit> bulkResponse = bulkRemoveDomainFromOrganisations(orgsForUpdate, domain);
         List<CivilServant> civilServants = bulkResponse.getUpdated().stream().flatMap(o -> o.getCivilServants().stream()).collect(Collectors.toList());
         log.info(String.format("Found %s civil servants in the selected departments", civilServants.size()));
-        Map<String, IdentityFromService> affectedIdentities = identityService.getIdentitiesMap(
+        Map<String, IdentityDTO> affectedIdentities = identityService.getIdentitiesMap(
                 civilServants.stream().map(cs -> cs.getIdentity().getUid()).collect(Collectors.toList()));
         civilServants = civilServants.stream().filter(cs -> {
-            IdentityFromService i = affectedIdentities.get(cs.getIdentity().getUid());
+            IdentityDTO i = affectedIdentities.get(cs.getIdentity().getUid());
             return i != null && i.getEmailDomain().equals(domain.getDomain());
         }).collect(Collectors.toList());
         log.info(String.format("%s civil servants in the selected departments have the domain '%s'. Removing their department",

--- a/src/main/java/uk/gov/cshr/civilservant/service/identity/IdentityDTO.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/identity/IdentityDTO.java
@@ -12,7 +12,7 @@ import java.util.Set;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class IdentityFromService {
+public class IdentityDTO {
 
   private String uid;
   private String username;

--- a/src/main/java/uk/gov/cshr/civilservant/service/identity/IdentityFromService.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/identity/IdentityFromService.java
@@ -1,27 +1,26 @@
 package uk.gov.cshr.civilservant.service.identity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import java.util.HashSet;
+import java.util.Set;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class IdentityFromService {
 
   private String uid;
-
   private String username;
+  private Set<String> roles = new HashSet<>();
 
-  public String getUid() {
-    return uid;
-  }
-
-  public void setUid(String uid) {
-    this.uid = uid;
-  }
-
-  public String getUsername() {
-    return username;
-  }
-
-  public void setUsername(String username) {
-    this.username = username;
+  @JsonIgnore
+  public String getEmailDomain() {
+    return username.split("@")[1];
   }
 
   @Override

--- a/src/main/java/uk/gov/cshr/civilservant/service/identity/IdentityService.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/identity/IdentityService.java
@@ -80,16 +80,16 @@ public class IdentityService {
         });
     }
 
-    public IdentityFromService findByEmail(String email) {
+    public IdentityDTO findByEmail(String email) {
 
         UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(identityAPIUrl)
                 .queryParam("emailAddress", email);
 
         log.debug(" Checking email {}", email);
-        IdentityFromService identity;
+        IdentityDTO identity;
 
         try {
-            identity = restOperations.getForObject(builder.toUriString(), IdentityFromService.class);
+            identity = restOperations.getForObject(builder.toUriString(), IdentityDTO.class);
         } catch (HttpClientErrorException http) {
             if (http.getStatusCode() == HttpStatus.NOT_FOUND) {
                 return null; // we kind of have to assume 403 is email not found rather than service not there ...
@@ -102,15 +102,15 @@ public class IdentityService {
     }
 
 
-    public Map<String, IdentityFromService> getIdentitiesMap(List<String> uids) {
+    public Map<String, IdentityDTO> getIdentitiesMap(List<String> uids) {
         List<String> failedUids = new ArrayList<>();
-        Map<String, IdentityFromService> uidsMap = new HashMap<>();
+        Map<String, IdentityDTO> uidsMap = new HashMap<>();
         Lists.partition(uids, 50).forEach(batch -> {
             String uidsBatchString = String.join(",", uids);
             UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(mapForUidsUrl)
                     .queryParam("uids", uidsBatchString);
             RequestEntity<Void> req = new RequestEntity<>(HttpMethod.GET, builder.build().toUri());
-            Map<String, IdentityFromService> resp = restOperations.exchange(req, new ParameterizedTypeReference<Map<String, IdentityFromService>>() {}).getBody();
+            Map<String, IdentityDTO> resp = restOperations.exchange(req, new ParameterizedTypeReference<Map<String, IdentityDTO>>() {}).getBody();
             if (resp == null) {
                 log.error(String.format("Null response when removing admin access from uids: %s", batch));
                 failedUids.addAll(batch);
@@ -125,11 +125,11 @@ public class IdentityService {
         return uidsMap;
     }
 
-    public IdentityFromService getIdentityFromService(String uid) {
+    public IdentityDTO getIdentityFromService(String uid) {
         try {
             UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(identityAPIUrl)
                 .queryParam("uid", uid);
-            return restOperations.getForObject(builder.toUriString(), IdentityFromService.class);
+            return restOperations.getForObject(builder.toUriString(), IdentityDTO.class);
         } catch (HttpClientErrorException e) {
             if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
                 return null;
@@ -142,7 +142,7 @@ public class IdentityService {
     public String getEmailAddress(CivilServant civilServant) {
 
         log.debug("Getting email address for civil servant {}", civilServant);
-        IdentityFromService identity = getIdentityFromService(civilServant.getIdentity().getUid());
+        IdentityDTO identity = getIdentityFromService(civilServant.getIdentity().getUid());
         if (identity != null) {
             return identity.getUsername();
         }

--- a/src/main/java/uk/gov/cshr/civilservant/service/identity/IdentityService.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/identity/IdentityService.java
@@ -125,7 +125,7 @@ public class IdentityService {
         return uidsMap;
     }
 
-    public IdentityDTO getIdentityFromService(String uid) {
+    public IdentityDTO getidentity(String uid) {
         try {
             UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(identityAPIUrl)
                 .queryParam("uid", uid);
@@ -142,7 +142,7 @@ public class IdentityService {
     public String getEmailAddress(CivilServant civilServant) {
 
         log.debug("Getting email address for civil servant {}", civilServant);
-        IdentityDTO identity = getIdentityFromService(civilServant.getIdentity().getUid());
+        IdentityDTO identity = getidentity(civilServant.getIdentity().getUid());
         if (identity != null) {
             return identity.getUsername();
         }

--- a/src/main/java/uk/gov/cshr/civilservant/service/identity/model/BatchProcessResponse.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/identity/model/BatchProcessResponse.java
@@ -1,0 +1,16 @@
+package uk.gov.cshr.civilservant.service.identity.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Collections;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BatchProcessResponse {
+    private List<String> successfulIds = Collections.emptyList();
+    private List<String> failedIds = Collections.emptyList();
+}

--- a/src/main/java/uk/gov/cshr/civilservant/service/identity/model/RemoveReportingAccessInput.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/identity/model/RemoveReportingAccessInput.java
@@ -1,0 +1,12 @@
+package uk.gov.cshr.civilservant.service.identity.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class RemoveReportingAccessInput {
+    private List<String> uids;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,7 +54,7 @@ oauth:
 
 identity:
   identityAPIUrl: "${oauth.serviceUrl}/api/identities"
-  mapForUidsUrl: "${oauth.identityAPIUrl}/map-for-uids"
+  mapForUidsUrl: "${identity.identityAPIUrl}/map-for-uids"
   removeReportingRolesUrl: "${identity.identityAPIUrl}/remove-reporting-roles"
   agencyTokenUrl: "${oauth.serviceUrl}/agency/{agencyTokenUid}"
   identityAgencyTokenUrl: "${oauth.serviceUrl}/api/identity/agency/"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,6 +54,8 @@ oauth:
 
 identity:
   identityAPIUrl: "${oauth.serviceUrl}/api/identities"
+  mapForUidsUrl: "${oauth.serviceUrl}/map-for-uids"
+  removeReportingRolesUrl: "${identity.identityAPIUrl}/remove_reporting_roles"
   agencyTokenUrl: "${oauth.serviceUrl}/agency/{agencyTokenUid}"
   identityAgencyTokenUrl: "${oauth.serviceUrl}/api/identity/agency/"
 
@@ -74,7 +76,7 @@ agencyToken:
 
 domains:
   validation:
-    regex: ${DOMAIN_VALIDATION_REGEX:^([\w-]+\.)+[\w-]{2,4}$}
+    regex: ${DOMAIN_VALIDATION_REGEX:^([\w-]+\.)+[\w-]{2,6}$}
 
 ---
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,7 +55,7 @@ oauth:
 identity:
   identityAPIUrl: "${oauth.serviceUrl}/api/identities"
   mapForUidsUrl: "${oauth.serviceUrl}/map-for-uids"
-  removeReportingRolesUrl: "${identity.identityAPIUrl}/remove_reporting_roles"
+  removeReportingRolesUrl: "${identity.identityAPIUrl}/remove-reporting-roles"
   agencyTokenUrl: "${oauth.serviceUrl}/agency/{agencyTokenUid}"
   identityAgencyTokenUrl: "${oauth.serviceUrl}/api/identity/agency/"
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,7 +54,7 @@ oauth:
 
 identity:
   identityAPIUrl: "${oauth.serviceUrl}/api/identities"
-  mapForUidsUrl: "${oauth.serviceUrl}/map-for-uids"
+  mapForUidsUrl: "${oauth.identityAPIUrl}/map-for-uids"
   removeReportingRolesUrl: "${identity.identityAPIUrl}/remove-reporting-roles"
   agencyTokenUrl: "${oauth.serviceUrl}/agency/{agencyTokenUid}"
   identityAgencyTokenUrl: "${oauth.serviceUrl}/api/identity/agency/"

--- a/src/main/resources/db/migration/h2/V1.19.1__domains_data.sql
+++ b/src/main/resources/db/migration/h2/V1.19.1__domains_data.sql
@@ -8,4 +8,5 @@ INSERT INTO organisational_unit_domains (organisational_unit_id, domain_id) VALU
 (1, 3),
 (4, 2),
 (2, 1),
+(4, 1),
 (2, 3);

--- a/src/test/java/uk/gov/cshr/civilservant/config/IntegrationTestUserConfig.java
+++ b/src/test/java/uk/gov/cshr/civilservant/config/IntegrationTestUserConfig.java
@@ -1,0 +1,14 @@
+package uk.gov.cshr.civilservant.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.authentication.AuthenticationProvider;
+import uk.gov.cshr.civilservant.utils.CustomAuthProvider;
+
+@TestConfiguration
+public class IntegrationTestUserConfig {
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        return new CustomAuthProvider();
+    }
+}

--- a/src/test/java/uk/gov/cshr/civilservant/controller/CivilServantControllerTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/controller/CivilServantControllerTest.java
@@ -18,7 +18,7 @@ import uk.gov.cshr.civilservant.repository.OrganisationalUnitRepository;
 import uk.gov.cshr.civilservant.resource.CivilServantResource;
 import uk.gov.cshr.civilservant.resource.factory.CivilServantResourceFactory;
 import uk.gov.cshr.civilservant.service.LineManagerService;
-import uk.gov.cshr.civilservant.service.identity.IdentityFromService;
+import uk.gov.cshr.civilservant.service.identity.IdentityDTO;
 import uk.gov.cshr.civilservant.service.identity.IdentityService;
 
 import java.util.Optional;
@@ -65,7 +65,7 @@ public class CivilServantControllerTest extends CSRSControllerTestBase {
     @Test
     public void shouldReturnNotProcessableIfNoDetailForLoggedInUser() throws Exception {
 
-        when(lineManagerService.checkLineManager("learner@domain.com")).thenReturn(new IdentityFromService());
+        when(lineManagerService.checkLineManager("learner@domain.com")).thenReturn(new IdentityDTO());
 
         mockMvc.perform(
                 patch("/civilServants/manager?email=learner@domain.com").with(csrf())
@@ -77,7 +77,7 @@ public class CivilServantControllerTest extends CSRSControllerTestBase {
     @Test
     public void shouldReturnBadRequestIfSettingLineManagerToYourself() throws Exception {
 
-        IdentityFromService lineManager = new IdentityFromService();
+        IdentityDTO lineManager = new IdentityDTO();
         lineManager.setUid("myuid");
 
         when(lineManagerService.checkLineManager("learner@domain.com")).thenReturn(lineManager);
@@ -98,7 +98,7 @@ public class CivilServantControllerTest extends CSRSControllerTestBase {
     public void shouldReturnOkAndUpdateCivilServant() throws Exception {
         String lineManagerEmail = "manager@domain.com";
 
-        IdentityFromService lineManagerIdentity = new IdentityFromService();
+        IdentityDTO lineManagerIdentity = new IdentityDTO();
         lineManagerIdentity.setUid("mid");
 
         lineManagerIdentity.setUsername(lineManagerEmail);

--- a/src/test/java/uk/gov/cshr/civilservant/controller/v2/OrganisationalUnitControllerTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/controller/v2/OrganisationalUnitControllerTest.java
@@ -36,7 +36,8 @@ public class OrganisationalUnitControllerTest extends CSRSControllerTestBase {
                 .andExpect(jsonPath("name").value("DH Core"))
                 .andExpect(jsonPath("code").value("D21"))
                 .andExpect(jsonPath("abbreviation").value("DHC"))
-                .andExpect(jsonPath("domains[0].domain").value("some-domain.com"));
+                .andExpect(jsonPath("domains[0].domain").value("cabinetoffice.gov.uk"))
+                .andExpect(jsonPath("domains[1].domain").value("some-domain.com"));
     }
 
     @Test
@@ -52,7 +53,8 @@ public class OrganisationalUnitControllerTest extends CSRSControllerTestBase {
                 .andExpect(jsonPath("name").value("DH Core"))
                 .andExpect(jsonPath("code").value("D21"))
                 .andExpect(jsonPath("abbreviation").value("DHC"))
-                .andExpect(jsonPath("domains[0].domain").value("some-domain.com"))
+                .andExpect(jsonPath("domains[0].domain").value("cabinetoffice.gov.uk"))
+                .andExpect(jsonPath("domains[1].domain").value("some-domain.com"))
                 .andExpect(jsonPath("parent.domains[0].domain").value("another-domain.co.uk"))
                 .andExpect(jsonPath("parent.domains[1].domain").value("cabinetoffice.gov.uk"));
     }

--- a/src/test/java/uk/gov/cshr/civilservant/integration/BaseIntegrationTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/integration/BaseIntegrationTest.java
@@ -1,0 +1,17 @@
+package uk.gov.cshr.civilservant.integration;
+
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Rule;
+import uk.gov.cshr.civilservant.controller.CSRSControllerTestBase;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
+public class BaseIntegrationTest extends CSRSControllerTestBase {
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(options()
+            .port(9000)
+            .notifier(new ConsoleNotifier(true)), true);
+
+}

--- a/src/test/java/uk/gov/cshr/civilservant/integration/CivilServantControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/integration/CivilServantControllerIntegrationTest.java
@@ -9,7 +9,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.cshr.civilservant.config.IntegrationTestUserConfig;
-import uk.gov.cshr.civilservant.service.identity.IdentityFromService;
+import uk.gov.cshr.civilservant.service.identity.IdentityDTO;
 import uk.gov.cshr.civilservant.service.identity.model.BatchProcessResponse;
 import uk.gov.cshr.civilservant.utils.CustomAuthentication;
 
@@ -49,7 +49,7 @@ public class CivilServantControllerIntegrationTest extends BaseIntegrationTest {
     @Test
     public void shouldThrowExceptionWhenUpdatingCivilServantToIncorrectOrganisation() throws Exception {
         stubPostClientToken();
-        stubGetIdentityWithUid("learner", new IdentityFromService(
+        stubGetIdentityWithUid("learner", new IdentityDTO(
                 "learner", "learner@domain.com", new HashSet<>(Collections.singletonList("LEARNER"))
         ));
         mockMvc.perform(
@@ -68,7 +68,7 @@ public class CivilServantControllerIntegrationTest extends BaseIntegrationTest {
     @Test
     public void shouldUpdateRestrictedCivilServantsOrganisation() throws Exception {
         stubPostClientToken();
-        stubGetIdentityWithUid("learner", new IdentityFromService(
+        stubGetIdentityWithUid("learner", new IdentityDTO(
                 "learner", "learner@cabinetoffice.gov.uk", new HashSet<>(Collections.singletonList("LEARNER"))
         ));
         stubPostRemoveReportingAccess(Collections.singletonList("learner"),
@@ -87,7 +87,7 @@ public class CivilServantControllerIntegrationTest extends BaseIntegrationTest {
     @Test
     public void shouldUpdateUnrestrictedCivilServantsOrganisation() throws Exception {
         stubPostClientToken();
-        stubGetIdentityWithUid("learner", new IdentityFromService(
+        stubGetIdentityWithUid("learner", new IdentityDTO(
                 "learner", "learner@cabinetoffice.gov.uk", new HashSet<>(Collections.singletonList("UNRESTRICTED_ORGANISATION"))
         ));
         mockMvc.perform(

--- a/src/test/java/uk/gov/cshr/civilservant/integration/CivilServantControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/integration/CivilServantControllerIntegrationTest.java
@@ -1,0 +1,102 @@
+package uk.gov.cshr.civilservant.integration;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.cshr.civilservant.config.IntegrationTestUserConfig;
+import uk.gov.cshr.civilservant.service.identity.IdentityFromService;
+import uk.gov.cshr.civilservant.service.identity.model.BatchProcessResponse;
+import uk.gov.cshr.civilservant.utils.CustomAuthentication;
+
+import java.util.Collections;
+import java.util.HashSet;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.cshr.civilservant.utils.apiStubs.IdentityServiceStub.*;
+
+@SpringBootTest(classes = IntegrationTestUserConfig.class)
+@AutoConfigureMockMvc
+@RunWith(SpringRunner.class)
+@Transactional
+public class CivilServantControllerIntegrationTest extends BaseIntegrationTest {
+    private final Authentication learner = new CustomAuthentication(Collections.singletonList(new SimpleGrantedAuthority("LEARNER")), "learner");
+
+    @Test
+    public void shouldGetCurrentCivilServant() throws Exception {
+        mockMvc.perform(
+                        get("/civilServants/me")
+                                .accept(APPLICATION_JSON)
+                                .with(authentication(learner)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.fullName", equalTo("Learner")))
+                .andExpect(jsonPath("$.organisationalUnit.id", equalTo(2)))
+                .andExpect(jsonPath("$.profession.id", equalTo(1)))
+                .andExpect(jsonPath("$.identity.uid", equalTo("learner")));
+
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenUpdatingCivilServantToIncorrectOrganisation() throws Exception {
+        stubPostClientToken();
+        stubGetIdentityWithUid("learner", new IdentityFromService(
+                "learner", "learner@domain.com", new HashSet<>(Collections.singletonList("LEARNER"))
+        ));
+        mockMvc.perform(
+                        patch("/civilServants/me/organisationalUnit")
+                                .accept(APPLICATION_JSON)
+                                .contentType(APPLICATION_JSON)
+                                .with(authentication(learner))
+                                .content("{\"organisationalUnitId\": 1}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors[0]", equalTo("User domain 'domain.com' does not exist on organisation '1', valid domains are: [another-domain.co.uk, cabinetoffice.gov.uk]")))
+                .andExpect(jsonPath("$.apiErrorCode.code", equalTo("CS001")))
+                .andExpect(jsonPath("$.apiErrorCode.description", equalTo("Civil servant email domain does not match organisation")));
+
+    }
+
+    @Test
+    public void shouldUpdateRestrictedCivilServantsOrganisation() throws Exception {
+        stubPostClientToken();
+        stubGetIdentityWithUid("learner", new IdentityFromService(
+                "learner", "learner@cabinetoffice.gov.uk", new HashSet<>(Collections.singletonList("LEARNER"))
+        ));
+        stubPostRemoveReportingAccess(Collections.singletonList("learner"),
+                new BatchProcessResponse(Collections.singletonList("learner"), Collections.emptyList()));
+        mockMvc.perform(
+                        patch("/civilServants/me/organisationalUnit")
+                                .accept(APPLICATION_JSON)
+                                .contentType(APPLICATION_JSON)
+                                .with(authentication(learner))
+                                .content("{\"organisationalUnitId\": 2}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.organisationalUnit.id", equalTo(2)));
+
+    }
+
+    @Test
+    public void shouldUpdateUnrestrictedCivilServantsOrganisation() throws Exception {
+        stubPostClientToken();
+        stubGetIdentityWithUid("learner", new IdentityFromService(
+                "learner", "learner@cabinetoffice.gov.uk", new HashSet<>(Collections.singletonList("UNRESTRICTED_ORGANISATION"))
+        ));
+        mockMvc.perform(
+                        patch("/civilServants/me/organisationalUnit")
+                                .accept(APPLICATION_JSON)
+                                .contentType(APPLICATION_JSON)
+                                .with(authentication(learner))
+                                .content("{\"organisationalUnitId\": 2}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.organisationalUnit.id", equalTo(2)));
+    }
+}

--- a/src/test/java/uk/gov/cshr/civilservant/integration/OrganisationUnitIntegrationTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/integration/OrganisationUnitIntegrationTest.java
@@ -14,7 +14,7 @@ import uk.gov.cshr.civilservant.repository.CivilServantRepository;
 import uk.gov.cshr.civilservant.repository.DomainRepository;
 import uk.gov.cshr.civilservant.repository.OrganisationalUnitRepository;
 import uk.gov.cshr.civilservant.service.OrganisationalUnitService;
-import uk.gov.cshr.civilservant.service.identity.IdentityFromService;
+import uk.gov.cshr.civilservant.service.identity.IdentityDTO;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -179,8 +179,8 @@ public class OrganisationUnitIntegrationTest extends BaseIntegrationTest {
     @Test
     public void shouldDeleteDomainAndCascade() throws Exception {
         stubPostClientToken();
-        IdentityFromService identity = new IdentityFromService("learner", "learner@cabinetoffice.gov.uk", Collections.singleton("LEARNER"));
-        Map<String, IdentityFromService> responseMap = new HashMap<String, IdentityFromService>() {{
+        IdentityDTO identity = new IdentityDTO("learner", "learner@cabinetoffice.gov.uk", Collections.singleton("LEARNER"));
+        Map<String, IdentityDTO> responseMap = new HashMap<String, IdentityDTO>() {{
             put("learner", identity);
         }};
         stubGetIdentitiesMap(Collections.singletonList("learner"), responseMap);
@@ -199,8 +199,8 @@ public class OrganisationUnitIntegrationTest extends BaseIntegrationTest {
     @Test
     public void shouldDeleteDomainAndCascadeAndRemoveOrganisationFromUser() throws Exception {
         stubPostClientToken();
-        IdentityFromService identity = new IdentityFromService("learner", "learner@cabinetoffice.gov.uk", Collections.singleton("LEARNER"));
-        Map<String, IdentityFromService> responseMap = new HashMap<String, IdentityFromService>() {{
+        IdentityDTO identity = new IdentityDTO("learner", "learner@cabinetoffice.gov.uk", Collections.singleton("LEARNER"));
+        Map<String, IdentityDTO> responseMap = new HashMap<String, IdentityDTO>() {{
             put("learner", identity);
         }};
         stubGetIdentitiesMap(Collections.singletonList("learner"), responseMap);

--- a/src/test/java/uk/gov/cshr/civilservant/service/IdentityServiceTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/service/IdentityServiceTest.java
@@ -5,8 +5,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.mockito.*;
-import org.springframework.beans.factory.annotation.Value;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Captor;
+import org.mockito.Mock;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.client.OAuth2RestOperations;
@@ -16,7 +18,6 @@ import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.cshr.civilservant.dto.IdentityAgencyResponseDTO;
 import uk.gov.cshr.civilservant.exception.CSRSApplicationException;
-import uk.gov.cshr.civilservant.exception.NoOrganisationsFoundException;
 import uk.gov.cshr.civilservant.exception.TokenDoesNotExistException;
 import uk.gov.cshr.civilservant.service.identity.IdentityFromService;
 import uk.gov.cshr.civilservant.service.identity.IdentityService;
@@ -40,10 +41,13 @@ public class IdentityServiceTest {
     private static final String USER_UID = "myuseruid";
 
     private static final String IDENTITY_API_URL = "http://localhost/identity";
+    private String MAP_FOR_UIDS_URL = "http://localhost:8080/api/api/identities";
 
     private String AGENCY_TOKEN_URL = "http://localhost:8080/agency/{agencyTokenUid}";
 
     private String IDENTITY_AGENCY_TOKEN_URL = "http://localhost:8080/identity/agency/";
+
+    private String REMOVE_REPORTING_ACCESS_URL = "http://localhost:8080/api/identities/remove_reportng_access";
 
     private IdentityService identityService;
 
@@ -66,7 +70,8 @@ public class IdentityServiceTest {
     @Before
     public void setup() {
         initMocks(this);
-        identityService = new IdentityService(restOperations, IDENTITY_API_URL, AGENCY_TOKEN_URL, IDENTITY_AGENCY_TOKEN_URL);
+        identityService = new IdentityService(restOperations, IDENTITY_API_URL, MAP_FOR_UIDS_URL, AGENCY_TOKEN_URL,
+                IDENTITY_AGENCY_TOKEN_URL, REMOVE_REPORTING_ACCESS_URL);
     }
 
     @Test

--- a/src/test/java/uk/gov/cshr/civilservant/service/IdentityServiceTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/service/IdentityServiceTest.java
@@ -19,7 +19,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.cshr.civilservant.dto.IdentityAgencyResponseDTO;
 import uk.gov.cshr.civilservant.exception.CSRSApplicationException;
 import uk.gov.cshr.civilservant.exception.TokenDoesNotExistException;
-import uk.gov.cshr.civilservant.service.identity.IdentityFromService;
+import uk.gov.cshr.civilservant.service.identity.IdentityDTO;
 import uk.gov.cshr.civilservant.service.identity.IdentityService;
 import uk.gov.cshr.civilservant.service.identity.model.AgencyTokenCapacityUsed;
 
@@ -77,32 +77,32 @@ public class IdentityServiceTest {
     @Test
     public void shouldReturnFoundIdentities() {
 
-        IdentityFromService identity = new IdentityFromService();
+        IdentityDTO identity = new IdentityDTO();
         identity.setUid("uid");
         identity.setUsername("shouldReturnUriStringFromOrg@domain.com");
 
         UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(IDENTITY_API_URL)
                 .queryParam("emailAddress", identity.getUsername());
 
-        when(restOperations.getForObject(builder.toUriString(), IdentityFromService.class)).thenReturn(identity);
+        when(restOperations.getForObject(builder.toUriString(), IdentityDTO.class)).thenReturn(identity);
 
-        IdentityFromService foundIdentity = identityService.findByEmail(identity.getUsername());
+        IdentityDTO foundIdentity = identityService.findByEmail(identity.getUsername());
         assertThat(foundIdentity.getUsername(), equalTo("shouldReturnUriStringFromOrg@domain.com"));
     }
 
     @Test
     public void shouldNotReturnNotFoundIdentities() {
 
-        IdentityFromService identity = new IdentityFromService();
+        IdentityDTO identity = new IdentityDTO();
         identity.setUid("uid");
         identity.setUsername("shouldReturnUriStringFromOrg@domain.com");
 
         UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(IDENTITY_API_URL)
                 .queryParam("emailAddress", identity.getUsername());
 
-        when(restOperations.getForObject(builder.toUriString(), IdentityFromService.class)).thenReturn(null);
+        when(restOperations.getForObject(builder.toUriString(), IdentityDTO.class)).thenReturn(null);
 
-        IdentityFromService foundIdentity = identityService.findByEmail(identity.getUsername());
+        IdentityDTO foundIdentity = identityService.findByEmail(identity.getUsername());
         assertNull(foundIdentity);
     }
 

--- a/src/test/java/uk/gov/cshr/civilservant/service/LineManagerServiceTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/service/LineManagerServiceTest.java
@@ -1,10 +1,5 @@
 package uk.gov.cshr.civilservant.service;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -13,8 +8,13 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.cshr.civilservant.domain.CivilServant;
 import uk.gov.cshr.civilservant.domain.Identity;
 import uk.gov.cshr.civilservant.repository.CivilServantRepository;
-import uk.gov.cshr.civilservant.service.identity.IdentityFromService;
+import uk.gov.cshr.civilservant.service.identity.IdentityDTO;
 import uk.gov.cshr.civilservant.service.identity.IdentityService;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LineManagerServiceTest {
@@ -29,7 +29,7 @@ public class LineManagerServiceTest {
 
   @Test
   public void shouldFindExistingIdentity() {
-    when(identityService.findByEmail("learner@domain.com")).thenReturn(new IdentityFromService());
+    when(identityService.findByEmail("learner@domain.com")).thenReturn(new IdentityDTO());
     assertNotNull(lineManagerService.checkLineManager("learner@domain.com"));
   }
 
@@ -49,7 +49,7 @@ public class LineManagerServiceTest {
     final CivilServant manager = new CivilServant(managerIdentity);
     manager.setFullName("fullName");
 
-    final IdentityFromService lineManager = new IdentityFromService();
+    final IdentityDTO lineManager = new IdentityDTO();
     lineManager.setUid(managerIdentity.getUid());
     lineManager.setUsername("manager@domain.com");
 

--- a/src/test/java/uk/gov/cshr/civilservant/service/OrganisationalUnitServiceTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/service/OrganisationalUnitServiceTest.java
@@ -600,7 +600,7 @@ public class OrganisationalUnitServiceTest {
         orgUnit3.setId(3L);
         List<OrganisationalUnit> orgs = Arrays.asList(orgUnit, orgUnit2, orgUnit3);
 
-        BulkUpdate resp = organisationalUnitService.bulkAddDomainToOrganisations(orgs, domain);
+        BulkUpdate<OrganisationalUnit> resp = organisationalUnitService.bulkAddDomainToOrganisations(orgs, domain);
         assertEquals(resp.getSkippedIds().size(), 1);
         assertEquals(resp.getUpdatedIds().size(), 2);
         assertEquals(2L, resp.getSkippedIds().get(0).longValue());

--- a/src/test/java/uk/gov/cshr/civilservant/utils/CustomAuthProvider.java
+++ b/src/test/java/uk/gov/cshr/civilservant/utils/CustomAuthProvider.java
@@ -1,0 +1,17 @@
+package uk.gov.cshr.civilservant.utils;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+
+public class CustomAuthProvider implements AuthenticationProvider {
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        return authentication;
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return true;
+    }
+}

--- a/src/test/java/uk/gov/cshr/civilservant/utils/CustomAuthentication.java
+++ b/src/test/java/uk/gov/cshr/civilservant/utils/CustomAuthentication.java
@@ -1,0 +1,33 @@
+package uk.gov.cshr.civilservant.utils;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class CustomAuthentication extends AbstractAuthenticationToken {
+
+    private final String username;
+
+    /**
+     * Creates a token with the supplied array of authorities.
+     *
+     * @param authorities the collection of <tt>GrantedAuthority</tt>s for the principal
+     *                    represented by this authentication object.
+     */
+    public CustomAuthentication(Collection<? extends GrantedAuthority> authorities,
+                                String username) {
+        super(authorities);
+        this.username = username;
+    }
+
+    @Override
+    public Object getCredentials() {
+        return username;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return username;
+    }
+}

--- a/src/test/java/uk/gov/cshr/civilservant/utils/apiStubs/IdentityServiceStub.java
+++ b/src/test/java/uk/gov/cshr/civilservant/utils/apiStubs/IdentityServiceStub.java
@@ -1,0 +1,67 @@
+package uk.gov.cshr.civilservant.utils.apiStubs;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import uk.gov.cshr.civilservant.service.identity.IdentityFromService;
+import uk.gov.cshr.civilservant.service.identity.model.BatchProcessResponse;
+import uk.gov.cshr.civilservant.service.identity.model.RemoveReportingAccessInput;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static uk.gov.cshr.civilservant.utils.JsonUtils.asJsonString;
+
+public class IdentityServiceStub {
+
+    private final static String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZSI6WyJyZWFkIiwid3JpdGUiXSwiZXhwIjoxNzAxMzQ5NTU3LCJhdXRob3JpdGllcyI6WyJDTElFTlQiXSwianRpIjoiMDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwIiwiY2xpZW50X2lkIjoiY2xpZW50In0.RJ8z56PjIoqd1C_8F_M9L5F3K1u_s83IujEcze2h6Zo";
+    public static void stubGetIdentityWithUid(String uid, IdentityFromService response) {
+        stubFor(
+                WireMock.get(urlPathEqualTo("/api/identities"))
+                        .withHeader("Authorization", equalTo("Bearer " + token))
+                        .withQueryParam("uid", equalTo(uid))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(asJsonString(response)))
+        );
+    }
+
+    public static void stubPostClientToken() {
+        stubFor(
+                WireMock.post(urlPathEqualTo("/oauth/token"))
+                        .withHeader("Authorization", containing("Basic"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\n" +
+                                        String.format("    \"access_token\": \"%s\",\n", token) +
+                                        "    \"token_type\": \"bearer\",\n" +
+                                        "    \"expires_in\": 80000,\n" +
+                                        "    \"scope\": \"read write\",\n" +
+                                        "    \"jti\": \"00000000-0000-0000-0000-000000000000\"\n" +
+                                        "}"))
+        );
+    }
+    
+    public static void stubPostRemoveReportingAccess(List<String> uids, BatchProcessResponse response) {
+        RemoveReportingAccessInput uidsObj = new RemoveReportingAccessInput(uids);
+        stubFor(
+                WireMock.post(urlPathEqualTo("/api/identities/remove_reporting_roles"))
+                        .withHeader("Authorization", equalTo("Bearer " + token))
+                        .withRequestBody(equalTo(asJsonString(uidsObj)))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(asJsonString(response)))
+        );
+    }
+
+    public static void stubGetIdentitiesMap(List<String> uids, Map<String, IdentityFromService> response) {
+        String uidsBatchString = String.join(",", uids);
+        stubFor(
+                WireMock.get(urlPathEqualTo("/api/identities/map-for-uids"))
+                        .withHeader("Authorization", equalTo("Bearer " + token))
+                        .withQueryParam("uids", equalTo(uidsBatchString))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(asJsonString(response)))
+        );
+    }
+}

--- a/src/test/java/uk/gov/cshr/civilservant/utils/apiStubs/IdentityServiceStub.java
+++ b/src/test/java/uk/gov/cshr/civilservant/utils/apiStubs/IdentityServiceStub.java
@@ -44,7 +44,7 @@ public class IdentityServiceStub {
     public static void stubPostRemoveReportingAccess(List<String> uids, BatchProcessResponse response) {
         RemoveReportingAccessInput uidsObj = new RemoveReportingAccessInput(uids);
         stubFor(
-                WireMock.post(urlPathEqualTo("/api/identities/remove_reporting_roles"))
+                WireMock.post(urlPathEqualTo("/api/identities/remove-reporting-roles"))
                         .withHeader("Authorization", equalTo("Bearer " + token))
                         .withRequestBody(equalTo(asJsonString(uidsObj)))
                         .willReturn(aResponse()

--- a/src/test/java/uk/gov/cshr/civilservant/utils/apiStubs/IdentityServiceStub.java
+++ b/src/test/java/uk/gov/cshr/civilservant/utils/apiStubs/IdentityServiceStub.java
@@ -1,7 +1,7 @@
 package uk.gov.cshr.civilservant.utils.apiStubs;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
-import uk.gov.cshr.civilservant.service.identity.IdentityFromService;
+import uk.gov.cshr.civilservant.service.identity.IdentityDTO;
 import uk.gov.cshr.civilservant.service.identity.model.BatchProcessResponse;
 import uk.gov.cshr.civilservant.service.identity.model.RemoveReportingAccessInput;
 
@@ -14,7 +14,7 @@ import static uk.gov.cshr.civilservant.utils.JsonUtils.asJsonString;
 public class IdentityServiceStub {
 
     private final static String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZSI6WyJyZWFkIiwid3JpdGUiXSwiZXhwIjoxNzAxMzQ5NTU3LCJhdXRob3JpdGllcyI6WyJDTElFTlQiXSwianRpIjoiMDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwIiwiY2xpZW50X2lkIjoiY2xpZW50In0.RJ8z56PjIoqd1C_8F_M9L5F3K1u_s83IujEcze2h6Zo";
-    public static void stubGetIdentityWithUid(String uid, IdentityFromService response) {
+    public static void stubGetIdentityWithUid(String uid, IdentityDTO response) {
         stubFor(
                 WireMock.get(urlPathEqualTo("/api/identities"))
                         .withHeader("Authorization", equalTo("Bearer " + token))
@@ -53,7 +53,7 @@ public class IdentityServiceStub {
         );
     }
 
-    public static void stubGetIdentitiesMap(List<String> uids, Map<String, IdentityFromService> response) {
+    public static void stubGetIdentitiesMap(List<String> uids, Map<String, IdentityDTO> response) {
         String uidsBatchString = String.join(",", uids);
         stubFor(
                 WireMock.get(urlPathEqualTo("/api/identities/map-for-uids"))

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -53,7 +53,7 @@ identity:
   identityAPIUrl: "${oauth.serviceUrl}/api/identities"
   mapForUidsUrl: "${identity.identityAPIUrl}/map-for-uids"
   agencyTokenUrl: "${oauth.serviceUrl}/agency/{agencyTokenUid}"
-  removeReportingRolesUrl: "${identity.identityAPIUrl}/remove_reporting_roles"
+  removeReportingRolesUrl: "${identity.identityAPIUrl}/remove-reporting-roles"
   identityAgencyTokenUrl: "${oauth.serviceUrl}/api/identity/agency/"
 
 govNotify:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -39,9 +39,9 @@ logging:
     com.zaxxer.hikari: INFO
 
 oauth:
-  clientId: ${CLIENT_ID:9fbd4ae2-2db3-44c7-9544-88e80255b56e}
-  clientSecret: ${CLIENT_SECRET:test}
-  serviceUrl: ${OAUTH_SERVICE_URL:http://localhost:8080}
+  clientId: client
+  clientSecret: test
+  serviceUrl: http://localhost:9000
   checkTokenEndpointUrl: "${oauth.serviceUrl}/oauth/check_token"
   tokenUrl: "${oauth.serviceUrl}/oauth/token"
   maxTotalConnections: 200
@@ -51,7 +51,9 @@ oauth:
 
 identity:
   identityAPIUrl: "${oauth.serviceUrl}/api/identities"
+  mapForUidsUrl: "${identity.identityAPIUrl}/map-for-uids"
   agencyTokenUrl: "${oauth.serviceUrl}/agency/{agencyTokenUid}"
+  removeReportingRolesUrl: "${identity.identityAPIUrl}/remove_reporting_roles"
   identityAgencyTokenUrl: "${oauth.serviceUrl}/api/identity/agency/"
 
 govNotify:

--- a/src/test/resources/db/migration/h2/V1.999__civil_servant_data.sql
+++ b/src/test/resources/db/migration/h2/V1.999__civil_servant_data.sql
@@ -1,0 +1,2 @@
+INSERT INTO `identity` (id, uid) VALUES(999, 'learner');
+INSERT INTO civil_servant (identity_id, organisational_unit_id, grade_id, profession_id, full_name) VALUES(999, 2, 1, 1, 'Learner');


### PR DESCRIPTION
- Update user organisation `PATCH /civilServants/me/organisationalUnit`
    - Uses the logged in user's principal to fetch their CS profile
    - Checks if the user is allowed to move organisations, given their email address
    - If the user has `UNRESTRICTED_ORGANISATION` role (AKA a 'free agent'), then the user can move to any organisation
    - The user's reporting access will be removed regardless
- Delete organisation `DELETE /organisationalUnits/{id}`
    - Checks if any users will be 'orphaned' as a result of the deletion
    - If users are found, their reporting access will be removed
- Delete domain `DELETE /organisationalUnits/{id}/domains/{domainId}`
    - Checks if any users will be affected by the domain removal (i.e which users in the department will be affected by this domain being removed)
    - Clears organisational unit for affected users
- Introduced Wiremock and improved integration tests
- Refactoring