### PR TITLE
LC-2762: Optimise MySQL connection strings

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,12 +18,14 @@ spring:
         dialect: uk.gov.cshr.civilservant.config.CustomMySqlDialect
         show_sql: false
         format_sql: false
+  database:
+    host: ${DATABASE_HOST:jdbc:mysql://localhost:3306}
+    name: ${DATABASE_NAME:identity}
+    use-ssl: ${DATABASE_USESSL:false}
   datasource:
-    host: ${DATASOURCE_HOST:localhost}
-    database: ${DATASOURCE_DATABASE:identity}
-    username: ${DATASOURCE_USERNAME:root}
-    password: ${DATASOURCE_PASSWORD:password}
-    url: ${DATASOURCE:jdbc:mysql://${spring.datasource.host}:3306/${spring.datasource.database}?user=${spring.datasource.username}&password=${spring.datasource.password}&useSSL=false}
+    url: ${DATASOURCE_URL:${database.host}/${database.name}?useSSL=${database.use-ssl}&requireSSL=true}
+    username: ${DATASOURCE_USERNAME:username}
+    password: ${DATASOURCE_PASSWORD:my-secret-pw}
     platform: mysql
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
     name: ${DATABASE_NAME:identity}
     use-ssl: ${DATABASE_USESSL:false}
   datasource:
-    url: ${DATASOURCE_URL:${database.host}/${database.name}?useSSL=${database.use-ssl}&requireSSL=true}
+    url: ${DATASOURCE_URL:${database.host}/${database.name}?useSSL=${database.use-ssl}&requireSSL=false}
     username: ${DATASOURCE_USERNAME:username}
     password: ${DATASOURCE_PASSWORD:my-secret-pw}
     platform: mysql

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,11 @@ spring:
         show_sql: false
         format_sql: false
   datasource:
-    url: ${DATASOURCE:jdbc:mysql://localhost:3306/csrs?user=root&password=my-secret-pw&useSSL=false}
+    host: ${DATASOURCE_HOST:localhost}
+    database: ${DATASOURCE_DATABASE:identity}
+    username: ${DATASOURCE_USERNAME:root}
+    password: ${DATASOURCE_PASSWORD:password}
+    url: ${DATASOURCE:jdbc:mysql://${spring.datasource.host}:3306/${spring.datasource.database}?user=${spring.datasource.username}&password=${spring.datasource.password}&useSSL=false}
     platform: mysql
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 database:
   host: ${DATABASE_HOST:jdbc:mysql://localhost:3306}
-  name: ${DATABASE_NAME:identity}
+  name: ${DATABASE_NAME:csrs}
   use-ssl: ${DATABASE_USESSL:false}
   
 spring:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,8 @@
+database:
+  host: ${DATABASE_HOST:jdbc:mysql://localhost:3306}
+  name: ${DATABASE_NAME:identity}
+  use-ssl: ${DATABASE_USESSL:false}
+  
 spring:
   rest:
       detection-strategy: annotated
@@ -18,10 +23,6 @@ spring:
         dialect: uk.gov.cshr.civilservant.config.CustomMySqlDialect
         show_sql: false
         format_sql: false
-  database:
-    host: ${DATABASE_HOST:jdbc:mysql://localhost:3306}
-    name: ${DATABASE_NAME:identity}
-    use-ssl: ${DATABASE_USESSL:false}
   datasource:
     url: ${DATASOURCE_URL:${database.host}/${database.name}?useSSL=${database.use-ssl}&requireSSL=false}
     username: ${DATASOURCE_USERNAME:username}


### PR DESCRIPTION
This change breaks up the connection strings into its individual components: host, database name, username, password and Use SSL. These environment variables are being introduced:

* `DATABASE_HOST`
* `DATABASE_NAME`
* `DATASOURCE_USERNAME`
* `DATASOURCE_PASSWORD`
* `DATABASE_USESSL`

The `spring.datasource.url` is then formed out of the above components.

This also removes the need for the `DATASOURCE` environment variable