### PR TITLE
LC 2805 mismatched domain

### DIFF
--- a/src/main/java/uk/gov/cshr/civilservant/controller/CivilServantController.java
+++ b/src/main/java/uk/gov/cshr/civilservant/controller/CivilServantController.java
@@ -73,7 +73,7 @@ public class CivilServantController implements ResourceProcessor<RepositoryLinks
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    @GetMapping("/me/login")
+    @PostMapping("/me/login")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<Resource<CivilServantResource>> performLogin(@RequestBody IdentityDTO dto) {
         log.debug("Checking civil servant login details & fetching the profile");

--- a/src/main/java/uk/gov/cshr/civilservant/controller/CivilServantController.java
+++ b/src/main/java/uk/gov/cshr/civilservant/controller/CivilServantController.java
@@ -73,6 +73,15 @@ public class CivilServantController implements ResourceProcessor<RepositoryLinks
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @GetMapping("/me/login")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Resource<CivilServantResource>> performLogin(@RequestBody IdentityDTO dto) {
+        log.debug("Checking civil servant login details & fetching the profile");
+        return civilServantService.performLogin(dto).map(
+                        civilServant -> ResponseEntity.ok(civilServantResourceFactory.create(civilServant)))
+                .orElse(ResponseEntity.notFound().build());
+    }
+
     @PatchMapping("/me/organisationalUnit")
     @PreAuthorize("isAuthenticated()")
     @ResponseBody

--- a/src/main/java/uk/gov/cshr/civilservant/domain/OrganisationalUnit.java
+++ b/src/main/java/uk/gov/cshr/civilservant/domain/OrganisationalUnit.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Entity
 public class OrganisationalUnit extends SelfReferencingEntity<OrganisationalUnit> {
@@ -181,19 +182,37 @@ public class OrganisationalUnit extends SelfReferencingEntity<OrganisationalUnit
     }
 
     @JsonIgnore
+    public Collection<String> getAgencyDomains() {
+        Collection<String> domains = Collections.emptyList();
+        if (this.agencyToken != null) {
+            domains = this.agencyToken.getAgencyDomains().stream().map(AgencyDomain::getDomain).collect(Collectors.toList());
+        }
+        return domains;
+    }
+
+    @JsonIgnore
+    public Collection<String> getDomainStrings() {
+        return this.domains.stream().map(Domain::getDomain).collect(Collectors.toList());
+    }
+
+    @JsonIgnore
     public boolean doesDomainExistInAgencyToken(String domain) {
-        return this.agencyToken != null && this.agencyToken.getAgencyDomains().stream().map(AgencyDomain::getDomain)
-                .anyMatch(d -> d.equals(domain));
+        return getAgencyDomains().contains(domain);
     }
 
     @JsonIgnore
     public boolean doesDomainExistInLinkedDomains(String domain) {
-        return this.domains.stream().anyMatch(d -> d.getDomain().equals(domain));
+        return getDomainStrings().contains(domain);
     }
 
     @JsonIgnore
     public boolean doesDomainExist(String domain) {
         return doesDomainExistInLinkedDomains(domain) || doesDomainExistInAgencyToken(domain);
+    }
+
+    @JsonIgnore
+    public String getValidDomainsString() {
+        return String.format("Linked domains: %s | Agency domains: %s", getDomainStrings(), getAgencyDomains());
     }
 
     @JsonIgnore

--- a/src/main/java/uk/gov/cshr/civilservant/domain/OrganisationalUnit.java
+++ b/src/main/java/uk/gov/cshr/civilservant/domain/OrganisationalUnit.java
@@ -181,8 +181,19 @@ public class OrganisationalUnit extends SelfReferencingEntity<OrganisationalUnit
     }
 
     @JsonIgnore
-    public boolean doesDomainExist(String domain) {
+    public boolean doesDomainExistInAgencyToken(String domain) {
+        return this.agencyToken != null && this.agencyToken.getAgencyDomains().stream().map(AgencyDomain::getDomain)
+                .anyMatch(d -> d.equals(domain));
+    }
+
+    @JsonIgnore
+    public boolean doesDomainExistInLinkedDomains(String domain) {
         return this.domains.stream().anyMatch(d -> d.getDomain().equals(domain));
+    }
+
+    @JsonIgnore
+    public boolean doesDomainExist(String domain) {
+        return doesDomainExistInLinkedDomains(domain) || doesDomainExistInAgencyToken(domain);
     }
 
     @JsonIgnore

--- a/src/main/java/uk/gov/cshr/civilservant/domain/OrganisationalUnit.java
+++ b/src/main/java/uk/gov/cshr/civilservant/domain/OrganisationalUnit.java
@@ -1,14 +1,12 @@
 package uk.gov.cshr.civilservant.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.extern.slf4j.Slf4j;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.*;
 
 @Entity
-@Slf4j
 public class OrganisationalUnit extends SelfReferencingEntity<OrganisationalUnit> {
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/uk/gov/cshr/civilservant/domain/OrganisationalUnit.java
+++ b/src/main/java/uk/gov/cshr/civilservant/domain/OrganisationalUnit.java
@@ -1,13 +1,14 @@
 package uk.gov.cshr.civilservant.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Entity
+@Slf4j
 public class OrganisationalUnit extends SelfReferencingEntity<OrganisationalUnit> {
 
     private static final long serialVersionUID = 1L;
@@ -182,37 +183,8 @@ public class OrganisationalUnit extends SelfReferencingEntity<OrganisationalUnit
     }
 
     @JsonIgnore
-    public Collection<String> getAgencyDomains() {
-        Collection<String> domains = Collections.emptyList();
-        if (this.agencyToken != null) {
-            domains = this.agencyToken.getAgencyDomains().stream().map(AgencyDomain::getDomain).collect(Collectors.toList());
-        }
-        return domains;
-    }
-
-    @JsonIgnore
-    public Collection<String> getDomainStrings() {
-        return this.domains.stream().map(Domain::getDomain).collect(Collectors.toList());
-    }
-
-    @JsonIgnore
-    public boolean doesDomainExistInAgencyToken(String domain) {
-        return getAgencyDomains().contains(domain);
-    }
-
-    @JsonIgnore
-    public boolean doesDomainExistInLinkedDomains(String domain) {
-        return getDomainStrings().contains(domain);
-    }
-
-    @JsonIgnore
     public boolean doesDomainExist(String domain) {
-        return doesDomainExistInLinkedDomains(domain) || doesDomainExistInAgencyToken(domain);
-    }
-
-    @JsonIgnore
-    public String getValidDomainsString() {
-        return String.format("Linked domains: %s | Agency domains: %s", getDomainStrings(), getAgencyDomains());
+        return this.domains.stream().anyMatch(d -> d.getDomain().equals(domain));
     }
 
     @JsonIgnore

--- a/src/main/java/uk/gov/cshr/civilservant/repository/OrganisationalUnitRepository.java
+++ b/src/main/java/uk/gov/cshr/civilservant/repository/OrganisationalUnitRepository.java
@@ -41,5 +41,17 @@ public interface OrganisationalUnitRepository extends SelfReferencingEntityRepos
     @Override
     List<OrganisationalUnit> findAll();
 
+    @Query("select ou " +
+            "from OrganisationalUnit ou " +
+            "join ou.domains d " +
+            "where d.domain = ?1")
+    List<OrganisationalUnit> findByDomain(String domain);
+
+    @Query("select ou " +
+            "from OrganisationalUnit ou " +
+            "join ou.agencyToken.agencyDomains d " +
+            "where d.domain = ?1")
+    List<OrganisationalUnit> findByAgencyDomain(String domain);
+
     Page<OrganisationalUnit> findAllByIdIn(Iterable<Long> ids, Pageable pageable);
 }

--- a/src/main/java/uk/gov/cshr/civilservant/service/CivilServantService.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/CivilServantService.java
@@ -16,6 +16,7 @@ import uk.gov.cshr.civilservant.service.identity.IdentityService;
 
 import java.util.Collections;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -39,6 +40,20 @@ public class CivilServantService {
             return cs.getIdentity().getUid();
         }
         throw new CivilServantNotFoundException();
+    }
+
+    public Optional<CivilServant> performLogin(IdentityDTO identity) {
+        return civilServantRepository.findByPrincipal()
+            .map(cs -> {
+                String csDomain = identity.getEmailDomain();
+                cs.getOrganisationalUnit().ifPresent(o -> {
+                    if(!o.doesDomainExist(csDomain)) {
+                        cs.setOrganisationalUnit(null);
+                        civilServantRepository.saveAndFlush(cs);
+                    }
+                });
+                return cs;
+            });
     }
 
     public CivilServant updateMyOrganisationalUnit(Long organisationalUnitId) {

--- a/src/main/java/uk/gov/cshr/civilservant/service/CivilServantService.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/CivilServantService.java
@@ -3,7 +3,6 @@ package uk.gov.cshr.civilservant.service;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.cshr.civilservant.domain.CivilServant;
-import uk.gov.cshr.civilservant.domain.Domain;
 import uk.gov.cshr.civilservant.domain.OrganisationalUnit;
 import uk.gov.cshr.civilservant.exception.CivilServantNotFoundException;
 import uk.gov.cshr.civilservant.exception.UserNotFoundException;
@@ -17,7 +16,6 @@ import uk.gov.cshr.civilservant.service.identity.IdentityService;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -79,7 +77,7 @@ public class CivilServantService {
                 identityService.removeReportingAccess(Collections.singletonList(uid));
             } else {
                 throw new InvalidUserOrganisationException(String.format("User domain '%s' does not exist on organisation '%s', valid domains are: %s",
-                        userDomain, organisationalUnitId, organisationalUnit.getDomains().stream().map(Domain::getDomain).collect(Collectors.toList())));
+                        userDomain, organisationalUnitId, organisationalUnit.getValidDomainsString()));
             }
             civilServantRepository.saveAndFlush(cs);
         } else {

--- a/src/main/java/uk/gov/cshr/civilservant/service/CivilServantService.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/CivilServantService.java
@@ -9,6 +9,7 @@ import uk.gov.cshr.civilservant.exception.CivilServantNotFoundException;
 import uk.gov.cshr.civilservant.exception.UserNotFoundException;
 import uk.gov.cshr.civilservant.exception.civilServant.InvalidUserOrganisationException;
 import uk.gov.cshr.civilservant.exception.organisationalUnit.OrganisationalUnitNotFoundException;
+import uk.gov.cshr.civilservant.repository.AgencyTokenRepository;
 import uk.gov.cshr.civilservant.repository.CivilServantRepository;
 import uk.gov.cshr.civilservant.service.identity.IdentityDTO;
 import uk.gov.cshr.civilservant.service.identity.IdentityService;
@@ -25,6 +26,7 @@ public class CivilServantService {
     private final CivilServantRepository civilServantRepository;
     private final IdentityService identityService;
     private final OrganisationalUnitService organisationalUnitService;
+    private final AgencyTokenRepository agencyTokenRepository;
 
     public String getCivilServantUid() {
         CivilServant cs = civilServantRepository.findByPrincipal()
@@ -39,12 +41,14 @@ public class CivilServantService {
         return civilServantRepository.findByPrincipal()
             .map(cs -> {
                 String csDomain = identity.getEmailDomain();
-                cs.getOrganisationalUnit().ifPresent(o -> {
-                    if(!o.doesDomainExist(csDomain)) {
-                        cs.setOrganisationalUnit(null);
-                        civilServantRepository.saveAndFlush(cs);
-                    }
-                });
+                if (!agencyTokenRepository.existsByDomain(csDomain)) {
+                    cs.getOrganisationalUnit().ifPresent(o -> {
+                        if(!o.doesDomainExist(csDomain)) {
+                            cs.setOrganisationalUnit(null);
+                            civilServantRepository.saveAndFlush(cs);
+                        }
+                    });
+                }
                 return cs;
             });
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,7 +56,6 @@ oauth:
 
 identity:
   identityAPIUrl: "${oauth.serviceUrl}/api/identities"
-  mapForUidsUrl: "${identity.identityAPIUrl}/map-for-uids"
   removeReportingRolesUrl: "${identity.identityAPIUrl}/remove-reporting-roles"
   agencyTokenUrl: "${oauth.serviceUrl}/agency/{agencyTokenUid}"
   identityAgencyTokenUrl: "${oauth.serviceUrl}/api/identity/agency/"

--- a/src/test/java/uk/gov/cshr/civilservant/integration/CivilServantControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/integration/CivilServantControllerIntegrationTest.java
@@ -59,7 +59,7 @@ public class CivilServantControllerIntegrationTest extends BaseIntegrationTest {
                                 .with(authentication(learner))
                                 .content("{\"organisationalUnitId\": 1}"))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errors[0]", equalTo("User domain 'domain.com' does not exist on organisation '1', valid domains are: Linked domains: [another-domain.co.uk, cabinetoffice.gov.uk] | Agency domains: [mydomain.com, example.com]")))
+                .andExpect(jsonPath("$.errors[0]", equalTo("User domain 'domain.com' does not exist on organisation '1' or any associated agency tokens")))
                 .andExpect(jsonPath("$.apiErrorCode.code", equalTo("CS001")))
                 .andExpect(jsonPath("$.apiErrorCode.description", equalTo("Civil servant email domain does not match organisation")));
 

--- a/src/test/java/uk/gov/cshr/civilservant/integration/CivilServantControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/integration/CivilServantControllerIntegrationTest.java
@@ -85,6 +85,25 @@ public class CivilServantControllerIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
+    public void shouldUpdateRestrictedCivilServantsAgencyOrganisation() throws Exception {
+        stubPostClientToken();
+        stubGetIdentityWithUid("learner", new IdentityDTO(
+                "learner", "learner@mydomain.com", new HashSet<>(Collections.singletonList("LEARNER"))
+        ));
+        stubPostRemoveReportingAccess(Collections.singletonList("learner"),
+                new BatchProcessResponse(Collections.singletonList("learner"), Collections.emptyList()));
+        mockMvc.perform(
+                        patch("/civilServants/me/organisationalUnit")
+                                .accept(APPLICATION_JSON)
+                                .contentType(APPLICATION_JSON)
+                                .with(authentication(learner))
+                                .content("{\"organisationalUnitId\": 1}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.organisationalUnit.id", equalTo(1)));
+
+    }
+
+    @Test
     public void shouldUpdateUnrestrictedCivilServantsOrganisation() throws Exception {
         stubPostClientToken();
         stubGetIdentityWithUid("learner", new IdentityDTO(

--- a/src/test/java/uk/gov/cshr/civilservant/integration/CivilServantControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/integration/CivilServantControllerIntegrationTest.java
@@ -59,7 +59,7 @@ public class CivilServantControllerIntegrationTest extends BaseIntegrationTest {
                                 .with(authentication(learner))
                                 .content("{\"organisationalUnitId\": 1}"))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errors[0]", equalTo("User domain 'domain.com' does not exist on organisation '1', valid domains are: [another-domain.co.uk, cabinetoffice.gov.uk]")))
+                .andExpect(jsonPath("$.errors[0]", equalTo("User domain 'domain.com' does not exist on organisation '1', valid domains are: Linked domains: [another-domain.co.uk, cabinetoffice.gov.uk] | Agency domains: [mydomain.com, example.com]")))
                 .andExpect(jsonPath("$.apiErrorCode.code", equalTo("CS001")))
                 .andExpect(jsonPath("$.apiErrorCode.description", equalTo("Civil servant email domain does not match organisation")));
 

--- a/src/test/java/uk/gov/cshr/civilservant/integration/OrganisationUnitIntegrationTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/integration/OrganisationUnitIntegrationTest.java
@@ -17,17 +17,13 @@ import uk.gov.cshr.civilservant.service.OrganisationalUnitService;
 import uk.gov.cshr.civilservant.service.identity.IdentityDTO;
 
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertFalse;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.cshr.civilservant.utils.apiStubs.IdentityServiceStub.stubGetIdentitiesMap;
 import static uk.gov.cshr.civilservant.utils.apiStubs.IdentityServiceStub.stubPostClientToken;
 
 @AutoConfigureMockMvc
@@ -180,10 +176,6 @@ public class OrganisationUnitIntegrationTest extends BaseIntegrationTest {
     public void shouldDeleteDomainAndCascade() throws Exception {
         stubPostClientToken();
         IdentityDTO identity = new IdentityDTO("learner", "learner@cabinetoffice.gov.uk", Collections.singleton("LEARNER"));
-        Map<String, IdentityDTO> responseMap = new HashMap<String, IdentityDTO>() {{
-            put("learner", identity);
-        }};
-        stubGetIdentitiesMap(Collections.singletonList("learner"), responseMap);
         CivilServant cs = civilServantRepository.findByIdentity("learner").get();
         mockMvc.perform(
                         delete("/organisationalUnits/2/domains/1")
@@ -193,28 +185,7 @@ public class OrganisationUnitIntegrationTest extends BaseIntegrationTest {
                 .andExpect(jsonPath("$.primaryOrganisationId", equalTo(2)))
                 .andExpect(jsonPath("$.updatedChildOrganisationIds.length()", equalTo(1)))
                 .andExpect(jsonPath("$.updatedChildOrganisationIds[0]", equalTo(4)));
-        assertFalse(cs.getOrganisationalUnit().isPresent());
    }
-
-    @Test
-    public void shouldDeleteDomainAndCascadeAndRemoveOrganisationFromUser() throws Exception {
-        stubPostClientToken();
-        IdentityDTO identity = new IdentityDTO("learner", "learner@cabinetoffice.gov.uk", Collections.singleton("LEARNER"));
-        Map<String, IdentityDTO> responseMap = new HashMap<String, IdentityDTO>() {{
-            put("learner", identity);
-        }};
-        stubGetIdentitiesMap(Collections.singletonList("learner"), responseMap);
-        CivilServant cs = civilServantRepository.findByIdentity("learner").get();
-        mockMvc.perform(
-                        delete("/organisationalUnits/2/domains/1")
-                                .param("includeSubOrgs", "true"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.domain.domain", equalTo("cabinetoffice.gov.uk")))
-                .andExpect(jsonPath("$.primaryOrganisationId", equalTo(2)))
-                .andExpect(jsonPath("$.updatedChildOrganisationIds.length()", equalTo(1)))
-                .andExpect(jsonPath("$.updatedChildOrganisationIds[0]", equalTo(4)));
-        assertFalse(cs.getOrganisationalUnit().isPresent());
-    }
 
     @Test
     public void shouldDeleteDomainAndNotCascade() throws Exception {

--- a/src/test/java/uk/gov/cshr/civilservant/repository/OrganisationalUnitRepositoryTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/repository/OrganisationalUnitRepositoryTest.java
@@ -7,14 +7,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.cshr.civilservant.domain.AgencyDomain;
 import uk.gov.cshr.civilservant.domain.AgencyToken;
 import uk.gov.cshr.civilservant.domain.Domain;
 import uk.gov.cshr.civilservant.domain.OrganisationalUnit;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
@@ -33,6 +31,46 @@ public class OrganisationalUnitRepositoryTest {
 
     @Autowired
     private AgencyTokenRepository agencyTokenRepository;
+
+    @Test
+    public void shouldGetOrganisationalUnitsWithDomain() {
+        Domain d = domainRepository.save(new Domain("test-find-by-domain.com"));
+        OrganisationalUnit org = new OrganisationalUnit();
+        org.setCode("org");
+        org.setName("org");
+        org.addDomain(d);
+        repository.saveAndFlush(org);
+        OrganisationalUnit org2 = new OrganisationalUnit();
+        org2.setCode("org2");
+        org2.setName("org2");
+        org2.addDomain(d);
+        repository.saveAndFlush(org2);
+
+        List<OrganisationalUnit> result = repository.findByDomain("test-find-by-domain.com");
+        assertEquals(2, result.size());
+        assertEquals("org", result.get(0).getCode());
+        assertEquals("org2", result.get(1).getCode());
+    }
+
+    @Test
+    public void shouldGetOrganisationalUnitsWithAgencyDomain() {
+        AgencyDomain ad = new AgencyDomain("agency-domain.com");
+        OrganisationalUnit org = new OrganisationalUnit();
+        org.setCode("org");
+        org.setName("org");
+        org.setAgencyToken(new AgencyToken("token","uid", 10, Collections.singleton(ad)));
+        repository.saveAndFlush(org);
+        OrganisationalUnit org2 = new OrganisationalUnit();
+        org2.setCode("org2");
+        org2.setName("org2");
+        org2.setAgencyToken(new AgencyToken("token2","uid2", 10, Collections.singleton(ad)));
+        repository.saveAndFlush(org2);
+
+        List<OrganisationalUnit> result = repository.findByAgencyDomain("agency-domain.com");
+        assertEquals(2, result.size());
+        assertEquals("org", result.get(0).getCode());
+        assertEquals("org2", result.get(1).getCode());
+    }
 
     @Test
     public void shouldDeleteDomainsInManyToManyRelationshipOnDelete() {

--- a/src/test/java/uk/gov/cshr/civilservant/service/CivilServantServiceTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/service/CivilServantServiceTest.java
@@ -12,6 +12,7 @@ import uk.gov.cshr.civilservant.domain.Domain;
 import uk.gov.cshr.civilservant.domain.Identity;
 import uk.gov.cshr.civilservant.domain.OrganisationalUnit;
 import uk.gov.cshr.civilservant.exception.CivilServantNotFoundException;
+import uk.gov.cshr.civilservant.repository.AgencyTokenRepository;
 import uk.gov.cshr.civilservant.repository.CivilServantRepository;
 import uk.gov.cshr.civilservant.service.identity.IdentityDTO;
 
@@ -29,6 +30,8 @@ public class CivilServantServiceTest {
 
     @Mock
     private CivilServantRepository civilServantRepository;
+    @Mock
+    private AgencyTokenRepository agencyTokenRepository;
 
     @InjectMocks
     private CivilServantService classUnderTest;
@@ -38,6 +41,7 @@ public class CivilServantServiceTest {
 
     @Test
     public void shouldPerformCsrsLoginCheckAndDeleteOrganisation() {
+        when(agencyTokenRepository.existsByDomain("civil-service.gov.uk")).thenReturn(false);
         IdentityDTO dto = new IdentityDTO("1", "CS@cs.gov.uk", Collections.singleton("ROLE"));
         OrganisationalUnit ou = new OrganisationalUnit();
         Domain domain = new Domain("civil-service.gov.uk");

--- a/src/test/java/uk/gov/cshr/civilservant/service/CivilServantServiceTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/service/CivilServantServiceTest.java
@@ -8,13 +8,18 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.cshr.civilservant.domain.CivilServant;
+import uk.gov.cshr.civilservant.domain.Domain;
 import uk.gov.cshr.civilservant.domain.Identity;
+import uk.gov.cshr.civilservant.domain.OrganisationalUnit;
 import uk.gov.cshr.civilservant.exception.CivilServantNotFoundException;
 import uk.gov.cshr.civilservant.repository.CivilServantRepository;
+import uk.gov.cshr.civilservant.service.identity.IdentityDTO;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
@@ -30,6 +35,20 @@ public class CivilServantServiceTest {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void shouldPerformCsrsLoginCheckAndDeleteOrganisation() {
+        IdentityDTO dto = new IdentityDTO("1", "CS@cs.gov.uk", Collections.singleton("ROLE"));
+        OrganisationalUnit ou = new OrganisationalUnit();
+        Domain domain = new Domain("civil-service.gov.uk");
+        ou.addDomain(domain);
+        Identity identity = new Identity("1");
+        CivilServant cs = new CivilServant(identity);
+        cs.setOrganisationalUnit(ou);
+        when(civilServantRepository.findByPrincipal()).thenReturn(Optional.of(cs));
+        Optional<CivilServant> resultOpt = classUnderTest.performLogin(dto);
+        assertFalse(resultOpt.get().getOrganisationalUnit().isPresent());
+    }
 
     @Test
     public void shouldReturnCivilServantUid() {

--- a/src/test/java/uk/gov/cshr/civilservant/service/CivilServantServiceTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/service/CivilServantServiceTest.java
@@ -41,7 +41,6 @@ public class CivilServantServiceTest {
 
     @Test
     public void shouldPerformCsrsLoginCheckAndDeleteOrganisation() {
-        when(agencyTokenRepository.existsByDomain("civil-service.gov.uk")).thenReturn(false);
         IdentityDTO dto = new IdentityDTO("1", "CS@cs.gov.uk", Collections.singleton("ROLE"));
         OrganisationalUnit ou = new OrganisationalUnit();
         Domain domain = new Domain("civil-service.gov.uk");

--- a/src/test/java/uk/gov/cshr/civilservant/service/IdentityServiceTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/service/IdentityServiceTest.java
@@ -70,7 +70,7 @@ public class IdentityServiceTest {
     @Before
     public void setup() {
         initMocks(this);
-        identityService = new IdentityService(restOperations, IDENTITY_API_URL, MAP_FOR_UIDS_URL, AGENCY_TOKEN_URL,
+        identityService = new IdentityService(restOperations, IDENTITY_API_URL, AGENCY_TOKEN_URL,
                 IDENTITY_AGENCY_TOKEN_URL, REMOVE_REPORTING_ACCESS_URL);
     }
 

--- a/src/test/java/uk/gov/cshr/civilservant/utils/apiStubs/IdentityServiceStub.java
+++ b/src/test/java/uk/gov/cshr/civilservant/utils/apiStubs/IdentityServiceStub.java
@@ -6,7 +6,6 @@ import uk.gov.cshr.civilservant.service.identity.model.BatchProcessResponse;
 import uk.gov.cshr.civilservant.service.identity.model.RemoveReportingAccessInput;
 
 import java.util.List;
-import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static uk.gov.cshr.civilservant.utils.JsonUtils.asJsonString;
@@ -53,15 +52,4 @@ public class IdentityServiceStub {
         );
     }
 
-    public static void stubGetIdentitiesMap(List<String> uids, Map<String, IdentityDTO> response) {
-        String uidsBatchString = String.join(",", uids);
-        stubFor(
-                WireMock.get(urlPathEqualTo("/api/identities/map-for-uids"))
-                        .withHeader("Authorization", equalTo("Bearer " + token))
-                        .withQueryParam("uids", equalTo(uidsBatchString))
-                        .willReturn(aResponse()
-                                .withHeader("Content-Type", "application/json")
-                                .withBody(asJsonString(response)))
-        );
-    }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -53,7 +53,6 @@ oauth:
 
 identity:
   identityAPIUrl: "${oauth.serviceUrl}/api/identities"
-  mapForUidsUrl: "${identity.identityAPIUrl}/map-for-uids"
   agencyTokenUrl: "${oauth.serviceUrl}/agency/{agencyTokenUid}"
   removeReportingRolesUrl: "${identity.identityAPIUrl}/remove-reporting-roles"
   identityAgencyTokenUrl: "${oauth.serviceUrl}/api/identity/agency/"


### PR DESCRIPTION
## LC-2805 mismatched domain
- Remove functionality to remove organisations from users when a domain is deleted
- New endpoint for checking a user's email domain against their organisation
    - Remove the users organisation if their domain does not match their registered organisation

## LC-2847 Agency token user changes domain
- Change organisation now performs a reverse-lookup on the domain, to determine if the organisation is valid. This check also extends to agency domains