### PR TITLE
LC-2775 Profession tree bug

### DIFF
--- a/src/main/java/uk/gov/cshr/civilservant/controller/ProfessionController.java
+++ b/src/main/java/uk/gov/cshr/civilservant/controller/ProfessionController.java
@@ -1,7 +1,5 @@
 package uk.gov.cshr.civilservant.controller;
 
-import java.util.List;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,6 +7,8 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.cshr.civilservant.domain.Profession;
 import uk.gov.cshr.civilservant.dto.ProfessionDto;
 import uk.gov.cshr.civilservant.service.ProfessionService;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/professions")
@@ -21,7 +21,7 @@ public class ProfessionController {
 
   @GetMapping("/tree")
   public ResponseEntity<List<Profession>> listProfessionsAsTreeStructure() {
-    List<Profession> professions = professionService.getParents();
+    List<Profession> professions = professionService.getTree();
 
     return ResponseEntity.ok(professions);
   }

--- a/src/main/java/uk/gov/cshr/civilservant/service/SelfReferencingEntityService.java
+++ b/src/main/java/uk/gov/cshr/civilservant/service/SelfReferencingEntityService.java
@@ -1,17 +1,18 @@
 package uk.gov.cshr.civilservant.service;
 
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.cshr.civilservant.domain.SelfReferencingEntity;
 import uk.gov.cshr.civilservant.dto.DtoEntity;
 import uk.gov.cshr.civilservant.dto.factory.DtoFactory;
 import uk.gov.cshr.civilservant.repository.SelfReferencingEntityRepository;
 
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Transactional
 public abstract class SelfReferencingEntityService<
-    T extends SelfReferencingEntity, K extends DtoEntity> {
+    T extends SelfReferencingEntity<T>, K extends DtoEntity> {
   private final DtoFactory<K, T> dtoFactory;
   private SelfReferencingEntityRepository<T> repository;
 
@@ -19,6 +20,24 @@ public abstract class SelfReferencingEntityService<
       SelfReferencingEntityRepository<T> repository, DtoFactory<K, T> dtoFactory) {
     this.repository = repository;
     this.dtoFactory = dtoFactory;
+  }
+
+  public List<T> getTree() {
+    List<T> list = this.getParents();
+    sortList(list);
+    return list;
+  }
+
+  private void sortList(List<T> list) {
+    list.forEach(entity ->
+            {
+              if (entity.hasChildren()) {
+                List<T> children = entity.getChildrenAsList();
+                children.sort(Comparator.comparing(T::getName, String.CASE_INSENSITIVE_ORDER));
+                sortList(children);
+              }
+            }
+    );
   }
 
   /** This will return all parent entities with any children as a list */

--- a/src/test/java/uk/gov/cshr/civilservant/controller/ProfessionControllerTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/controller/ProfessionControllerTest.java
@@ -37,7 +37,7 @@ public class ProfessionControllerTest extends CSRSControllerTestBase{
     parent1.setChildren(Arrays.asList(child1, child2));
     Profession parent2 = new Profession("Parent Two");
 
-    when(professionService.getParents()).thenReturn(Arrays.asList(parent1, parent2));
+    when(professionService.getTree()).thenReturn(Arrays.asList(parent1, parent2));
 
     mockMvc
         .perform(get("/professions/tree").accept(MediaType.APPLICATION_JSON))

--- a/src/test/java/uk/gov/cshr/civilservant/integration/ProfessionControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/cshr/civilservant/integration/ProfessionControllerIntegrationTest.java
@@ -1,0 +1,43 @@
+package uk.gov.cshr.civilservant.integration;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.cshr.civilservant.config.IntegrationTestUserConfig;
+import uk.gov.cshr.civilservant.utils.CustomAuthentication;
+
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(classes = IntegrationTestUserConfig.class)
+@AutoConfigureMockMvc
+@RunWith(SpringRunner.class)
+public class ProfessionControllerIntegrationTest extends BaseIntegrationTest {
+
+    private final Authentication learner = new CustomAuthentication(Collections.singletonList(new SimpleGrantedAuthority("LEARNER")), "learner");
+
+    @Test
+    public void testGetProfessionsAsTree() throws Exception {
+        mockMvc.perform(
+                        get("/professions/tree")
+                                .accept(APPLICATION_JSON)
+                                .with(authentication(learner)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id", equalTo(1)))
+                .andExpect(jsonPath("$[0].name", equalTo("Analysis")))
+                .andExpect(jsonPath("$[0].children[0].id", equalTo(100)))
+                .andExpect(jsonPath("$[0].children[0].name", equalTo("Analysis-child")))
+                .andExpect(jsonPath("$[0].children[0].children[0].id", equalTo(102)))
+                .andExpect(jsonPath("$[0].children[0].children[0].name", equalTo("Analysis-grandchild")));
+    }
+}

--- a/src/test/resources/db/migration/h2/V1.999__civil_servant_data.sql
+++ b/src/test/resources/db/migration/h2/V1.999__civil_servant_data.sql
@@ -1,2 +1,5 @@
 INSERT INTO `identity` (id, uid) VALUES(999, 'learner');
 INSERT INTO civil_servant (identity_id, organisational_unit_id, grade_id, profession_id, full_name) VALUES(999, 2, 1, 1, 'Learner');
+INSERT INTO profession (id, parent_id, name) VALUES(100, 1, 'Analysis-child');
+INSERT INTO profession (id, parent_id, name) VALUES(101, 2, 'Commercial-child');
+INSERT INTO profession (parent_id, name) VALUES(100, 'Analysis-grandchild');


### PR DESCRIPTION
- Fixed a bug when getting the profession tree. Lazy loading was causing Jackson to incorrectly serialize profession objects when getting the children in the hierarchy. This is now handled specifically in a service and returned.
- Added an integration test