### PR TITLE
LC-3008 fix other areas of work

### DIFF
--- a/src/main/java/uk/gov/cshr/civilservant/dto/ProfessionDto.java
+++ b/src/main/java/uk/gov/cshr/civilservant/dto/ProfessionDto.java
@@ -1,8 +1,3 @@
 package uk.gov.cshr.civilservant.dto;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-
-@EqualsAndHashCode(callSuper = false)
-@Data
 public class ProfessionDto extends DtoEntity {}


### PR DESCRIPTION
- Remove `EqualsAndHashCode` from the ProfessionDto class. This was causing all professionDto objects to be equal and as a result, when a set is created, only one profession would appear in the set.